### PR TITLE
GH 4112 add pagination to cross border balancing energy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-05-21
+
 ### Added
 - Cursor-based pagination for the cross-border balancing energy volumes endpoint (`/balancing/energy/cross-border-volumes`) via optional `cursor` and `limit` query parameters
 
@@ -124,7 +126,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UTC timestamp-based period filtering
 - OpenAPI 3.0.3 specification
 
-[Unreleased]: https://github.com/balancing-services/rest-api/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/balancing-services/rest-api/compare/v1.12.0...HEAD
+[1.12.0]: https://github.com/balancing-services/rest-api/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/balancing-services/rest-api/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/balancing-services/rest-api/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/balancing-services/rest-api/compare/v1.8.0...v1.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Cursor-based pagination for the cross-border balancing energy volumes endpoint (`/balancing/energy/cross-border-volumes`) via optional `cursor` and `limit` query parameters
+
+### Deprecated
+- The non-paginated mode of the cross-border balancing energy volumes endpoint (`/balancing/energy/cross-border-volumes`) — omitting both `cursor` and `limit` to receive the full result set in one response — is deprecated. In the next major version `limit` will take a default value when omitted, so requests will always be paginated rather than returning the full result set in a single response
+
 ## [1.11.0] - 2026-05-13
 
 ### Added

--- a/cli/balancing_services_cli/commands/energy.py
+++ b/cli/balancing_services_cli/commands/energy.py
@@ -38,6 +38,10 @@ log = logging.getLogger(__name__)
 AREA_CHOICES = [a.value for a in Area]
 RESERVE_TYPE_CHOICES = [r.value for r in ReserveType]
 
+# Max page size for the cross-border-volumes endpoint (its spec maximum). Passed
+# explicitly because this endpoint opts into pagination on cursor/limit presence.
+CROSS_BORDER_VOLUMES_PAGE_SIZE = 1000
+
 
 @click.command("energy-activated")
 @click.option(
@@ -258,29 +262,33 @@ def energy_cbpm(
     type=click.Choice(RESERVE_TYPE_CHOICES, case_sensitive=False),
     help="Reserve type.",
 )
+@click.option("--all/--first-page", "fetch_all", default=None, help="Fetch all pages or only the first page.")
 @click.pass_context
 def energy_cross_border_volumes(
-    ctx: click.Context, area: str, start: datetime, end: datetime, reserve_type: str,
+    ctx: click.Context, area: str, start: datetime, end: datetime, reserve_type: str, fetch_all: bool | None,
 ) -> None:
     """Fetch cross-border balancing energy volumes."""
+    if fetch_all is None:
+        raise click.UsageError("You must specify either --all or --first-page.")
     client = make_client(ctx)
     log.debug(
         "GET /balancing/energy/cross-border-volumes area=%s start=%s end=%s reserve_type=%s",
         area, start, end, reserve_type,
     )
-    response = call_with_retry(
+    fetch = fetch_all_pages if fetch_all else fetch_first_page
+    # Pagination on this endpoint is opt-in: unlike the sibling endpoints it has no
+    # server-side default limit, so we pass an explicit limit to engage pagination
+    # (and lift the 32-day period cap that applies to unpaginated requests).
+    data = fetch(
         get_cross_border_energy_volumes.sync_detailed,
         client=client,
         area=Area(area),
         period_start_at=start,
         period_end_at=end,
         reserve_type=ReserveType(reserve_type),
+        limit=CROSS_BORDER_VOLUMES_PAGE_SIZE,
     )
-    if response.status_code != 200:
-        raise SystemExit(format_api_error(response))
-    n_groups = len(response.parsed.data) if response.parsed else 0
-    log.debug("Response: HTTP %d, %d group(s)", response.status_code, n_groups)
-    rows = flatten_response(response.parsed.data, ENERGY_CROSS_BORDER_VOLUMES)
+    rows = flatten_response(data, ENERGY_CROSS_BORDER_VOLUMES)
     log.debug("Flattened to %d row(s)", len(rows))
     write_rows(rows, ctx.obj["output"], ctx.obj["fmt"])
 

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -339,6 +339,59 @@ def test_energy_cbpm_first_page_flag():
     assert result.exit_code == 0, result.output
 
 
+def test_energy_cross_border_volumes_requires_all_or_first_page():
+    """energy-cross-border-volumes must fail without --all or --first-page."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--token", "test-token", "energy-cross-border-volumes", *COMMON_BID_ARGS])
+    assert result.exit_code != 0
+    assert "--all" in result.output or "--first-page" in result.output
+
+
+def test_energy_cross_border_volumes_all_flag():
+    runner = CliRunner()
+    with patch(
+        "balancing_services_cli.commands.energy.get_cross_border_energy_volumes.sync_detailed",
+        return_value=_make_bids_response(),
+    ) as mock_fn:
+        result = runner.invoke(
+            cli, ["--token", "test-token", "energy-cross-border-volumes", "--all", *COMMON_BID_ARGS],
+        )
+    assert result.exit_code == 0, result.output
+    # Pagination is opt-in on this endpoint, so the command must pass an explicit limit.
+    assert mock_fn.call_args[1]["limit"] == 1000
+
+
+def test_energy_cross_border_volumes_first_page_flag():
+    runner = CliRunner()
+    with patch(
+        "balancing_services_cli.commands.energy.get_cross_border_energy_volumes.sync_detailed",
+        return_value=_make_bids_response(),
+    ) as mock_fn:
+        result = runner.invoke(
+            cli, ["--token", "test-token", "energy-cross-border-volumes", "--first-page", *COMMON_BID_ARGS],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_fn.call_args[1]["limit"] == 1000
+
+
+def test_energy_cross_border_volumes_follows_cursor():
+    """--all walks every page, forwarding the returned cursor."""
+    runner = CliRunner()
+    page1 = StubResponse(status_code=200, parsed=StubBidsParsed(data=[], has_more=True, next_cursor="c1"))
+    page2 = StubResponse(status_code=200, parsed=StubBidsParsed(data=[], has_more=False))
+    with patch(
+        "balancing_services_cli.commands.energy.get_cross_border_energy_volumes.sync_detailed",
+        side_effect=[page1, page2],
+    ) as mock_fn:
+        result = runner.invoke(
+            cli, ["--token", "test-token", "energy-cross-border-volumes", "--all", *COMMON_BID_ARGS],
+        )
+    assert result.exit_code == 0, result.output
+    assert mock_fn.call_count == 2
+    assert mock_fn.call_args_list[0][1].get("cursor") is None
+    assert mock_fn.call_args_list[1][1]["cursor"] == "c1"
+
+
 # ── Day-ahead energy prices tests ────────────────────────────────────────
 
 

--- a/clients/python/balancing_services/api/default/get_cross_border_energy_volumes.py
+++ b/clients/python/balancing_services/api/default/get_cross_border_energy_volumes.py
@@ -12,7 +12,7 @@ from ...models.cross_border_energy_volumes_response import (
 )
 from ...models.problem import Problem
 from ...models.reserve_type import ReserveType
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -21,6 +21,8 @@ def _get_kwargs(
     period_start_at: datetime.datetime,
     period_end_at: datetime.datetime,
     reserve_type: ReserveType,
+    cursor: str | Unset = UNSET,
+    limit: int | Unset = UNSET,
 ) -> dict[str, Any]:
 
     params: dict[str, Any] = {}
@@ -36,6 +38,10 @@ def _get_kwargs(
 
     json_reserve_type = reserve_type.value
     params["reserve-type"] = json_reserve_type
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -115,6 +121,8 @@ def sync_detailed(
     period_start_at: datetime.datetime,
     period_end_at: datetime.datetime,
     reserve_type: ReserveType,
+    cursor: str | Unset = UNSET,
+    limit: int | Unset = UNSET,
 ) -> Response[CrossBorderEnergyVolumesResponse | Problem]:
     """Get cross-border balancing energy volumes
 
@@ -124,6 +132,16 @@ def sync_detailed(
     are expressed as average power in MW
     and split by activation type — for mFRR, DIRECT and SCHEDULED activations are returned as separate
     entries.
+    Supports cursor-based pagination for large result sets.
+
+    **Deprecated:** The non-paginated mode — omitting both `cursor` and `limit` to receive the full
+    result set in a single
+    response (bounded to a 32-day period) — is deprecated. In the next major version `limit` will take a
+    default value when
+    omitted, so requests that omit `cursor` and `limit` will be paginated automatically (returning the
+    first page) instead of
+    returning the full result set. Opt into pagination now by passing `limit` and following
+    `nextCursor`.
 
     This endpoint is experimental and may be changed or removed without a deprecation period.
 
@@ -132,6 +150,8 @@ def sync_detailed(
         period_start_at (datetime.datetime):  Example: 2025-01-01T00:00:00Z.
         period_end_at (datetime.datetime):  Example: 2025-01-02T00:00:00Z.
         reserve_type (ReserveType): Reserve type
+        cursor (str | Unset):  Example: v1:AAAAAYwBAgMEBQYHCAkKCw==.
+        limit (int | Unset):  Example: 100.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -146,6 +166,8 @@ def sync_detailed(
         period_start_at=period_start_at,
         period_end_at=period_end_at,
         reserve_type=reserve_type,
+        cursor=cursor,
+        limit=limit,
     )
 
     response = client.get_httpx_client().request(
@@ -162,6 +184,8 @@ def sync(
     period_start_at: datetime.datetime,
     period_end_at: datetime.datetime,
     reserve_type: ReserveType,
+    cursor: str | Unset = UNSET,
+    limit: int | Unset = UNSET,
 ) -> CrossBorderEnergyVolumesResponse | Problem | None:
     """Get cross-border balancing energy volumes
 
@@ -171,6 +195,16 @@ def sync(
     are expressed as average power in MW
     and split by activation type — for mFRR, DIRECT and SCHEDULED activations are returned as separate
     entries.
+    Supports cursor-based pagination for large result sets.
+
+    **Deprecated:** The non-paginated mode — omitting both `cursor` and `limit` to receive the full
+    result set in a single
+    response (bounded to a 32-day period) — is deprecated. In the next major version `limit` will take a
+    default value when
+    omitted, so requests that omit `cursor` and `limit` will be paginated automatically (returning the
+    first page) instead of
+    returning the full result set. Opt into pagination now by passing `limit` and following
+    `nextCursor`.
 
     This endpoint is experimental and may be changed or removed without a deprecation period.
 
@@ -179,6 +213,8 @@ def sync(
         period_start_at (datetime.datetime):  Example: 2025-01-01T00:00:00Z.
         period_end_at (datetime.datetime):  Example: 2025-01-02T00:00:00Z.
         reserve_type (ReserveType): Reserve type
+        cursor (str | Unset):  Example: v1:AAAAAYwBAgMEBQYHCAkKCw==.
+        limit (int | Unset):  Example: 100.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -194,6 +230,8 @@ def sync(
         period_start_at=period_start_at,
         period_end_at=period_end_at,
         reserve_type=reserve_type,
+        cursor=cursor,
+        limit=limit,
     ).parsed
 
 
@@ -204,6 +242,8 @@ async def asyncio_detailed(
     period_start_at: datetime.datetime,
     period_end_at: datetime.datetime,
     reserve_type: ReserveType,
+    cursor: str | Unset = UNSET,
+    limit: int | Unset = UNSET,
 ) -> Response[CrossBorderEnergyVolumesResponse | Problem]:
     """Get cross-border balancing energy volumes
 
@@ -213,6 +253,16 @@ async def asyncio_detailed(
     are expressed as average power in MW
     and split by activation type — for mFRR, DIRECT and SCHEDULED activations are returned as separate
     entries.
+    Supports cursor-based pagination for large result sets.
+
+    **Deprecated:** The non-paginated mode — omitting both `cursor` and `limit` to receive the full
+    result set in a single
+    response (bounded to a 32-day period) — is deprecated. In the next major version `limit` will take a
+    default value when
+    omitted, so requests that omit `cursor` and `limit` will be paginated automatically (returning the
+    first page) instead of
+    returning the full result set. Opt into pagination now by passing `limit` and following
+    `nextCursor`.
 
     This endpoint is experimental and may be changed or removed without a deprecation period.
 
@@ -221,6 +271,8 @@ async def asyncio_detailed(
         period_start_at (datetime.datetime):  Example: 2025-01-01T00:00:00Z.
         period_end_at (datetime.datetime):  Example: 2025-01-02T00:00:00Z.
         reserve_type (ReserveType): Reserve type
+        cursor (str | Unset):  Example: v1:AAAAAYwBAgMEBQYHCAkKCw==.
+        limit (int | Unset):  Example: 100.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -235,6 +287,8 @@ async def asyncio_detailed(
         period_start_at=period_start_at,
         period_end_at=period_end_at,
         reserve_type=reserve_type,
+        cursor=cursor,
+        limit=limit,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -249,6 +303,8 @@ async def asyncio(
     period_start_at: datetime.datetime,
     period_end_at: datetime.datetime,
     reserve_type: ReserveType,
+    cursor: str | Unset = UNSET,
+    limit: int | Unset = UNSET,
 ) -> CrossBorderEnergyVolumesResponse | Problem | None:
     """Get cross-border balancing energy volumes
 
@@ -258,6 +314,16 @@ async def asyncio(
     are expressed as average power in MW
     and split by activation type — for mFRR, DIRECT and SCHEDULED activations are returned as separate
     entries.
+    Supports cursor-based pagination for large result sets.
+
+    **Deprecated:** The non-paginated mode — omitting both `cursor` and `limit` to receive the full
+    result set in a single
+    response (bounded to a 32-day period) — is deprecated. In the next major version `limit` will take a
+    default value when
+    omitted, so requests that omit `cursor` and `limit` will be paginated automatically (returning the
+    first page) instead of
+    returning the full result set. Opt into pagination now by passing `limit` and following
+    `nextCursor`.
 
     This endpoint is experimental and may be changed or removed without a deprecation period.
 
@@ -266,6 +332,8 @@ async def asyncio(
         period_start_at (datetime.datetime):  Example: 2025-01-01T00:00:00Z.
         period_end_at (datetime.datetime):  Example: 2025-01-02T00:00:00Z.
         reserve_type (ReserveType): Reserve type
+        cursor (str | Unset):  Example: v1:AAAAAYwBAgMEBQYHCAkKCw==.
+        limit (int | Unset):  Example: 100.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -282,5 +350,7 @@ async def asyncio(
             period_start_at=period_start_at,
             period_end_at=period_end_at,
             reserve_type=reserve_type,
+            cursor=cursor,
+            limit=limit,
         )
     ).parsed

--- a/clients/python/config.yaml
+++ b/clients/python/config.yaml
@@ -2,3 +2,9 @@ project_name_override: "balancing-services"
 package_name_override: "balancing_services"
 python_version: "3.10"
 use_union_operator: true
+# Format generated code at 88 columns (black's width) rather than letting
+# `ruff format` pick up the project's line-length of 120. Keeps the generated
+# client stable across regenerations regardless of the formatter's default.
+post_hooks:
+  - "ruff check --fix ."
+  - "ruff format --line-length 88 ."

--- a/clients/python/tests/test_integration.py
+++ b/clients/python/tests/test_integration.py
@@ -639,6 +639,40 @@ async def test_async_get_cross_border_energy_volumes(authenticated_client, mock_
     assert len(response.parsed.data) == 1
 
 
+@respx.mock
+def test_get_cross_border_energy_volumes_pagination(authenticated_client, mock_cross_border_energy_volumes_response):
+    """Test cross-border balancing energy volumes pagination - cursor/limit sent, nextCursor parsed."""
+    paginated_response = {
+        **mock_cross_border_energy_volumes_response,
+        "hasMore": True,
+        "nextCursor": "v1:AAAAAYwBAgMEBQYHCAkKCw==",
+    }
+
+    route = respx.get(
+        "https://api.balancing.services/v1/balancing/energy/cross-border-volumes"
+    ).mock(return_value=Response(200, json=paginated_response))
+
+    response = get_cross_border_energy_volumes.sync_detailed(
+        client=authenticated_client,
+        area=Area.FI,
+        period_start_at=datetime(2026, 3, 1, 0, 0, 0, tzinfo=timezone.utc),
+        period_end_at=datetime(2026, 3, 1, 1, 0, 0, tzinfo=timezone.utc),
+        reserve_type=ReserveType.AFRR,
+        cursor="v1:AAAAAYwBAgMEBQYHCAkKCw==",
+        limit=100,
+    )
+
+    assert response.status_code == 200
+    assert response.parsed is not None
+    assert response.parsed.has_more is True
+    assert response.parsed.next_cursor == "v1:AAAAAYwBAgMEBQYHCAkKCw=="
+    # The cursor/limit must actually be transmitted as query params (the cursor
+    # is what disambiguates the from->to / to->from union halves for this endpoint).
+    sent_url = route.calls.last.request.url
+    assert sent_url.params["cursor"] == "v1:AAAAAYwBAgMEBQYHCAkKCw=="
+    assert sent_url.params["limit"] == "100"
+
+
 @pytest.fixture
 def mock_day_ahead_energy_prices_response():
     """Mock response data for day-ahead energy prices."""

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1370,6 +1370,12 @@ paths:
         **EXPERIMENTAL**: Returns cross-border balancing energy volumes for the specified area and reserve type within the given time period.
         Returns both imports (where area is the destination) and exports (where area is the source). Volumes are expressed as average power in MW
         and split by activation type — for mFRR, DIRECT and SCHEDULED activations are returned as separate entries.
+        Supports cursor-based pagination for large result sets.
+
+        **Deprecated:** The non-paginated mode — omitting both `cursor` and `limit` to receive the full result set in a single
+        response (bounded to a 32-day period) — is deprecated. In the next major version `limit` will take a default value when
+        omitted, so requests that omit `cursor` and `limit` will be paginated automatically (returning the first page) instead of
+        returning the full result set. Opt into pagination now by passing `limit` and following `nextCursor`.
 
         This endpoint is experimental and may be changed or removed without a deprecation period.
       operationId: getCrossBorderEnergyVolumes
@@ -1405,6 +1411,30 @@ paths:
           schema:
             $ref: '#/components/schemas/ReserveType'
           example: 'aFRR'
+        - name: cursor
+          in: query
+          description: |
+            Pagination cursor from a previous response. Pagination is opt-in: supplying `cursor`
+            (and/or `limit`) switches the endpoint into cursor pagination. Omit both `cursor` and
+            `limit` to receive the full result set in a single response (bounded to a 32-day period).
+          required: false
+          schema:
+            type: string
+            example: 'v1:AAAAAYwBAgMEBQYHCAkKCw=='
+        - name: limit
+          in: query
+          description: |
+            Page size for cursor pagination (max 1000, defaults to 100 when paginating). Supplying it
+            enables pagination; omitting both `limit` and `cursor` returns the full result set in a
+            single response (bounded to a 32-day period). This single-response mode is deprecated: in the
+            next major version `limit` will default to a value when omitted, so responses will always be
+            paginated.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            example: 100
       responses:
         '200':
           description: Successful response

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Balancing Services REST API
-  version: 1.11.0
+  version: 1.12.0
   description: REST API for balancing services data
   contact:
     name: Balancing Services Team


### PR DESCRIPTION
- **Enforce 88 column lines for backwards compatibilty**
- **Add support for paginated requests for cross-border energy**
- **Release 1.12.0**
