### PR TITLE
GH 1387 enum validator mypy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Balancing Services REST API will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.1] - 2026-07-25
 
 ### Fixed
 - The official Python client's generated enum validators (`check_area`, `check_currency`, and the other `check_*` helpers) now type-check under mypy 1.x. The `literal_enums` output returned a bare `str` where a `Literal[...]` was expected, which only mypy 2.x accepts by narrowing the membership test; the validators now wrap the return in `cast(...)`, so `mypy` passes on every supported version. This is purely a static-typing fix — `cast` is a no-op at runtime, so there is no API, wire, or runtime-behaviour change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Balancing Services REST API will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- The official Python client's generated enum validators (`check_area`, `check_currency`, and the other `check_*` helpers) now type-check under mypy 1.x. The `literal_enums` output returned a bare `str` where a `Literal[...]` was expected, which only mypy 2.x accepts by narrowing the membership test; the validators now wrap the return in `cast(...)`, so `mypy` passes on every supported version. This is purely a static-typing fix — `cast` is a no-op at runtime, so there is no API, wire, or runtime-behaviour change
+
 ## [2.0.0] - 2026-07-25
 
 ### Added

--- a/clients/python/balancing_services/models/activation_type.py
+++ b/clients/python/balancing_services/models/activation_type.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 ActivationType = Literal["direct", "notApplicable", "scheduled", "unspecified"]
 
@@ -12,7 +12,7 @@ ACTIVATION_TYPE_VALUES: set[ActivationType] = {
 
 def check_activation_type(value: str) -> ActivationType:
     if value in ACTIVATION_TYPE_VALUES:
-        return value
+        return cast(ActivationType, value)
     raise TypeError(
         f"Unexpected value {value!r}. Expected one of {ACTIVATION_TYPE_VALUES!r}"
     )

--- a/clients/python/balancing_services/models/area.py
+++ b/clients/python/balancing_services/models/area.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 Area = Literal[
     "AT",
@@ -103,5 +103,5 @@ AREA_VALUES: set[Area] = {
 
 def check_area(value: str) -> Area:
     if value in AREA_VALUES:
-        return value
+        return cast(Area, value)
     raise TypeError(f"Unexpected value {value!r}. Expected one of {AREA_VALUES!r}")

--- a/clients/python/balancing_services/models/bid_status.py
+++ b/clients/python/balancing_services/models/bid_status.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 BidStatus = Literal["accepted", "offered"]
 
@@ -10,7 +10,7 @@ BID_STATUS_VALUES: set[BidStatus] = {
 
 def check_bid_status(value: str) -> BidStatus:
     if value in BID_STATUS_VALUES:
-        return value
+        return cast(BidStatus, value)
     raise TypeError(
         f"Unexpected value {value!r}. Expected one of {BID_STATUS_VALUES!r}"
     )

--- a/clients/python/balancing_services/models/currency.py
+++ b/clients/python/balancing_services/models/currency.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 Currency = Literal["BGN", "CHF", "EUR", "HUF", "PLN", "RON", "UAH"]
 
@@ -15,5 +15,5 @@ CURRENCY_VALUES: set[Currency] = {
 
 def check_currency(value: str) -> Currency:
     if value in CURRENCY_VALUES:
-        return value
+        return cast(Currency, value)
     raise TypeError(f"Unexpected value {value!r}. Expected one of {CURRENCY_VALUES!r}")

--- a/clients/python/balancing_services/models/demand_basis.py
+++ b/clients/python/balancing_services/models/demand_basis.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 DemandBasis = Literal["additive", "substitutive"]
 
@@ -10,7 +10,7 @@ DEMAND_BASIS_VALUES: set[DemandBasis] = {
 
 def check_demand_basis(value: str) -> DemandBasis:
     if value in DEMAND_BASIS_VALUES:
-        return value
+        return cast(DemandBasis, value)
     raise TypeError(
         f"Unexpected value {value!r}. Expected one of {DEMAND_BASIS_VALUES!r}"
     )

--- a/clients/python/balancing_services/models/direction.py
+++ b/clients/python/balancing_services/models/direction.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 Direction = Literal["down", "symmetric", "up"]
 
@@ -11,5 +11,5 @@ DIRECTION_VALUES: set[Direction] = {
 
 def check_direction(value: str) -> Direction:
     if value in DIRECTION_VALUES:
-        return value
+        return cast(Direction, value)
     raise TypeError(f"Unexpected value {value!r}. Expected one of {DIRECTION_VALUES!r}")

--- a/clients/python/balancing_services/models/eic_code.py
+++ b/clients/python/balancing_services/models/eic_code.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 EicCode = Literal[
     "10Y1001A1001A39I",
@@ -103,5 +103,5 @@ EIC_CODE_VALUES: set[EicCode] = {
 
 def check_eic_code(value: str) -> EicCode:
     if value in EIC_CODE_VALUES:
-        return value
+        return cast(EicCode, value)
     raise TypeError(f"Unexpected value {value!r}. Expected one of {EIC_CODE_VALUES!r}")

--- a/clients/python/balancing_services/models/imbalance_direction.py
+++ b/clients/python/balancing_services/models/imbalance_direction.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 ImbalanceDirection = Literal["negative", "positive", "symmetric"]
 
@@ -11,7 +11,7 @@ IMBALANCE_DIRECTION_VALUES: set[ImbalanceDirection] = {
 
 def check_imbalance_direction(value: str) -> ImbalanceDirection:
     if value in IMBALANCE_DIRECTION_VALUES:
-        return value
+        return cast(ImbalanceDirection, value)
     raise TypeError(
         f"Unexpected value {value!r}. Expected one of {IMBALANCE_DIRECTION_VALUES!r}"
     )

--- a/clients/python/balancing_services/models/reserve_type.py
+++ b/clients/python/balancing_services/models/reserve_type.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 ReserveType = Literal["aFRR", "FCR", "mFRR", "RR"]
 
@@ -12,7 +12,7 @@ RESERVE_TYPE_VALUES: set[ReserveType] = {
 
 def check_reserve_type(value: str) -> ReserveType:
     if value in RESERVE_TYPE_VALUES:
-        return value
+        return cast(ReserveType, value)
     raise TypeError(
         f"Unexpected value {value!r}. Expected one of {RESERVE_TYPE_VALUES!r}"
     )

--- a/clients/python/balancing_services/models/total_imbalance_direction.py
+++ b/clients/python/balancing_services/models/total_imbalance_direction.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 TotalImbalanceDirection = Literal["balanced", "deficit", "surplus"]
 
@@ -11,7 +11,7 @@ TOTAL_IMBALANCE_DIRECTION_VALUES: set[TotalImbalanceDirection] = {
 
 def check_total_imbalance_direction(value: str) -> TotalImbalanceDirection:
     if value in TOTAL_IMBALANCE_DIRECTION_VALUES:
-        return value
+        return cast(TotalImbalanceDirection, value)
     raise TypeError(
         f"Unexpected value {value!r}. Expected one of {TOTAL_IMBALANCE_DIRECTION_VALUES!r}"
     )

--- a/clients/python/config.yaml
+++ b/clients/python/config.yaml
@@ -21,6 +21,10 @@ literal_enums: true
 # client stable across regenerations regardless of the formatter's default.
 # `--exit-zero` so leftover unfixable lint (e.g. docstring whitespace) in the
 # generated code does not fail the generate step and abort generate.sh.
+# Pin ruff (via `uvx ruff@<version>`) exactly as generate.sh pins the generator:
+# a bare `ruff` resolves from PATH to whatever version happens to be cached,
+# and newer ruff applies extra pyupgrade rewrites (e.g. `-> Self`, `*args:
+# object`) that silently churn the generated client. Bump this deliberately.
 post_hooks:
-  - "ruff check --fix --exit-zero ."
-  - "ruff format --line-length 88 ."
+  - "uvx ruff@0.16.0 check --fix --exit-zero ."
+  - "uvx ruff@0.16.0 format --line-length 88 ."

--- a/clients/python/fix_enum_validator_casts.py
+++ b/clients/python/fix_enum_validator_casts.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Post-process generated literal-enum validators to be mypy-version-independent.
+
+openapi-python-client's literal_enums output generates, for each enum:
+
+    def check_area(value: str) -> Area:
+        if value in AREA_VALUES:
+            return value
+        raise TypeError(...)
+
+The bare `return value` returns `str` where a `Literal[...]` is expected. mypy only accepts it
+if it narrows `value` via the `value in AREA_VALUES` membership test — a feature added in mypy
+2.x — so on mypy 1.x all 10 validators fail with [return-value]. Wrap the return in cast() so the
+code type-checks on every mypy version. The project's mypy config sets neither
+warn_redundant_casts nor warn_unused_ignores, so the cast is harmless on mypy 2.x where it is
+technically redundant. Run from generate.sh after generation; `cast` is appended to the existing
+`from typing import ...` line, which is already the ruff/isort canonical order (types before
+lowercase names), so the output is stable regardless of the later ruff --fix pass.
+"""
+import pathlib
+import re
+
+MODELS = pathlib.Path(__file__).parent / "balancing_services" / "models"
+CHECK_RE = re.compile(r"^def check_\w+\(value: str\) -> (\w+):$", re.M)
+
+patched = []
+for path in sorted(MODELS.glob("*.py")):
+    src = path.read_text()
+    m = CHECK_RE.search(src)
+    if not m:
+        continue
+    type_name = m.group(1)
+    if "return cast(" in src:
+        continue  # already patched (idempotent)
+    if not re.search(r"^from typing import .*\bcast\b", src, re.M):
+        src = re.sub(
+            r"^from typing import (.+)$",
+            lambda mm: f"from typing import {mm.group(1)}, cast",
+            src,
+            count=1,
+            flags=re.M,
+        )
+    new_src, n = re.subn(
+        r"(\n    if value in \w+_VALUES:\n        )return value\n",
+        rf"\g<1>return cast({type_name}, value)\n",
+        src,
+    )
+    if n != 1:
+        raise SystemExit(f"{path}: expected exactly one validator return, found {n}")
+    path.write_text(new_src)
+    patched.append(path.name)
+
+print(f"Patched {len(patched)} literal-enum validator(s): {', '.join(patched)}")

--- a/clients/python/generate.sh
+++ b/clients/python/generate.sh
@@ -50,6 +50,9 @@ uvx openapi-python-client@0.29.0 generate \
     --config config.yaml \
     --meta none
 
+echo "Making literal-enum validators mypy-version-independent..."
+python3 fix_enum_validator_casts.py
+
 echo "Fixing types with Ruff..."
 uvx ruff check --fix balancing_services --exit-zero --quiet || true
 

--- a/clients/python/generate.sh
+++ b/clients/python/generate.sh
@@ -54,7 +54,9 @@ echo "Making literal-enum validators mypy-version-independent..."
 python3 fix_enum_validator_casts.py
 
 echo "Fixing types with Ruff..."
-uvx ruff check --fix balancing_services --exit-zero --quiet || true
+# Pin ruff (see config.yaml post_hooks) so generation is reproducible: an
+# unpinned `uvx ruff` upgrades to whatever is latest and churns the output.
+uvx ruff@0.16.0 check --fix balancing_services --exit-zero --quiet || true
 
 # --- Python 3.10 compatibility shim ------------------------------------------
 # openapi-python-client (>= 0.24) generates `datetime.datetime.fromisoformat()`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Balancing Services REST API
-  version: 2.0.0
+  version: 2.0.1
   description: REST API for balancing services data
   contact:
     name: Balancing Services Team


### PR DESCRIPTION
- **Fix mypy 1.x type-checking of the Python client's enum validators**
- **Pin ruff for reproducible client generation**
- **Release 2.0.1**
