### PR TITLE
Add a Claude Code skill covering API integration and v1-to-v2 migration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "balancing-services",
+  "owner": {
+    "name": "Balancing Services",
+    "email": "info@balancing.services",
+    "url": "https://balancing.services"
+  },
+  "plugins": [
+    {
+      "name": "balancing-services-rest-api",
+      "source": "./",
+      "description": "Skill for integrating with the Balancing Services REST API — European electricity balancing market data."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "balancing-services-rest-api",
+  "version": "2.0.2",
+  "description": "Skill for integrating with the Balancing Services REST API — European electricity balancing market data.",
+  "author": {
+    "name": "Balancing Services",
+    "url": "https://balancing.services"
+  },
+  "homepage": "https://balancing.services",
+  "repository": "https://github.com/balancing-services/rest-api",
+  "license": "MIT"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ This is a **public specification repository** containing the OpenAPI specificati
 - `openapi.yaml` - The canonical OpenAPI 3.0.3 specification (source of truth)
 - `README.md` - Public-facing documentation for API users
 - `CHANGELOG.md` - Version history following Keep a Changelog format
+- `skills/` - Claude Code skills shipped to API users; `balancing-services-api/` covers integrating with the API and migrating a v1 client to v2
+- `.claude-plugin/` - Makes this repository a Claude Code plugin marketplace containing itself as its single plugin (`marketplace.json`, `plugin.json`)
 - `LICENSE` - MIT License
 - `.gitignore` - Standard ignore patterns
 
@@ -53,7 +55,7 @@ This project follows [Semantic Versioning](https://semver.org/):
 
 ### Release Process
 
-1. Update version in `openapi.yaml` (info.version field)
+1. Update version in `openapi.yaml` (info.version field). `scripts/bump-version.sh` does this and also stamps the same version into `.claude-plugin/plugin.json`, which must match
 2. Update CHANGELOG.md with release date and version
 3. Commit changes
 4. Create annotated git tag: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Balancing Services REST API will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Claude Code skill (`skills/balancing-services-api/`) covering both integrating with the API and migrating an existing client from v1 to v2. It describes the endpoint catalogue and request semantics, the cursor-pagination and `updated-since` polling contracts, and RFC 7807 error handling, and carries a change-by-change v1 → v2 migration guide with before/after payloads and a checklist to walk against a client codebase
+- The repository doubles as a Claude Code plugin marketplace containing itself as its single plugin (`.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`), so the skill installs with `/plugin marketplace add balancing-services/rest-api` followed by `/plugin install balancing-services-rest-api@balancing-services`; see the README for preconfiguring it for a team. The plugin version tracks `openapi.yaml`'s `info.version` and is stamped by `scripts/bump-version.sh`
+
 ## [2.0.2] - 2026-07-25
 
 ### Fixed
@@ -206,7 +212,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UTC timestamp-based period filtering
 - OpenAPI 3.0.3 specification
 
-[Unreleased - 2.0.0]: https://github.com/balancing-services/rest-api/compare/v1.20.0...HEAD
+[Unreleased]: https://github.com/balancing-services/rest-api/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/balancing-services/rest-api/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/balancing-services/rest-api/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/balancing-services/rest-api/compare/v1.20.0...v2.0.0
 [1.20.0]: https://github.com/balancing-services/rest-api/compare/v1.19.0...v1.20.0
 [1.19.0]: https://github.com/balancing-services/rest-api/compare/v1.18.0...v1.19.0
 [1.18.0]: https://github.com/balancing-services/rest-api/compare/v1.17.0...v1.18.0
@@ -219,6 +228,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.11.0]: https://github.com/balancing-services/rest-api/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/balancing-services/rest-api/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/balancing-services/rest-api/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/balancing-services/rest-api/compare/v1.7.1...v1.8.0
 [1.7.1]: https://github.com/balancing-services/rest-api/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/balancing-services/rest-api/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/balancing-services/rest-api/compare/v1.5.1...v1.6.0

--- a/README.md
+++ b/README.md
@@ -102,6 +102,33 @@ if response.status_code == 200:
 
 For complete documentation, usage examples, and API reference, see [clients/python/README.md](./clients/python/README.md).
 
+## Claude Code Skill
+
+This repository doubles as a [Claude Code](https://claude.ai/code) plugin marketplace. The
+`balancing-services-api` skill teaches Claude Code how to integrate with this API — endpoints,
+pagination, incremental polling, error handling — and how to migrate an existing v1 client to v2.
+
+```
+/plugin marketplace add balancing-services/rest-api
+/plugin install balancing-services-rest-api@balancing-services
+```
+
+Marketplace auto-update is off by default; enable it under `/plugin` → Marketplaces to pick up new
+skill revisions automatically.
+
+To preconfigure the plugin for a team, commit this to the project's `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "balancing-services": {
+      "source": { "source": "github", "repo": "balancing-services/rest-api" }
+    }
+  },
+  "enabledPlugins": { "balancing-services-rest-api@balancing-services": true }
+}
+```
+
 ## Versioning
 
 This project follows [Semantic Versioning](https://semver.org/):

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,13 +4,13 @@ This directory contains automation scripts to simplify the release process for t
 
 ## Version Management
 
-The version is stored in **one place only**: `openapi.yaml`. The Python client's `pyproject.toml` is generated from `pyproject.toml.draft` which contains an invalid TOML placeholder (`version = __VERSION__`) that prevents accidental publishing without proper generation.
+The version is stored in **one place only**: `openapi.yaml`. The Python client's `pyproject.toml` is generated from `pyproject.toml.draft` which contains an invalid TOML placeholder (`version = __VERSION__`) that prevents accidental publishing without proper generation. The Claude Code plugin manifest (`.claude-plugin/plugin.json`) carries a copy of the version because the manifest format requires a literal value; `bump-version.sh` stamps it from `openapi.yaml`.
 
 ## Scripts
 
 ### `bump-version.sh`
 
-Bumps the version number in `openapi.yaml` and updates `CHANGELOG.md`.
+Bumps the version number in `openapi.yaml`, stamps it into `.claude-plugin/plugin.json`, and updates `CHANGELOG.md`.
 
 **Usage:**
 ```bash
@@ -24,6 +24,7 @@ Bumps the version number in `openapi.yaml` and updates `CHANGELOG.md`.
 
 **What it does:**
 - Updates `openapi.yaml` (info.version field) - **single source of truth**
+- Updates `.claude-plugin/plugin.json` (version field) to match
 - Adds new version section to `CHANGELOG.md` with current date
 - Shows next steps for committing and publishing
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script to bump version across the repository
-# Updates openapi.yaml, pyproject.toml, and CHANGELOG.md
+# Updates openapi.yaml, .claude-plugin/plugin.json, pyproject.toml, and CHANGELOG.md
 
 set -e
 
@@ -41,6 +41,10 @@ echo ""
 echo "Updating openapi.yaml..."
 sed -i "s/^  version: .*/  version: ${NEW_VERSION}/" openapi.yaml
 
+# Update the Claude Code plugin manifest - its version must match openapi.yaml
+echo "Updating .claude-plugin/plugin.json..."
+sed -i "s|^\(  \"version\": \"\).*\(\",\)$|\1${NEW_VERSION}\2|" .claude-plugin/plugin.json
+
 # Update CHANGELOG.md - add new Unreleased section and set date for current version
 echo "Updating CHANGELOG.md..."
 CURRENT_DATE=$(date +%Y-%m-%d)
@@ -74,6 +78,7 @@ echo -e "${GREEN}✓ Version updated successfully${NC}"
 echo ""
 echo "Files modified:"
 echo "  - openapi.yaml"
+echo "  - .claude-plugin/plugin.json"
 echo "  - CHANGELOG.md"
 echo ""
 echo "Note: pyproject.toml will be auto-generated from pyproject.toml.draft"

--- a/skills/balancing-services-api/SKILL.md
+++ b/skills/balancing-services-api/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: balancing-services-api
+description: Integrate with, query or migrate to the Balancing Services REST API (https://api.balancing.services/v2), which serves European electricity balancing market data — imbalance prices and volumes, balancing energy and capacity volumes, prices and bids, cross-border exchange, day-ahead prices. Use when writing or reviewing client code against this API, picking endpoints and parameters, building pagination or incremental-polling loops, or upgrading an existing v1 client to v2.
+---
+
+# Balancing Services REST API
+
+A commercial REST API over European electricity balancing market data: imbalance, balancing
+energy, balancing capacity, cross-border exchange and day-ahead prices, harmonised across TSOs
+and areas.
+
+- Base URL: `https://api.balancing.services/v2` (v1 remains served at `.../v1`)
+- Auth: `Authorization: Bearer <token>` on every request. Request a token from info@balancing.services
+- Interactive docs: https://api.balancing.services/v2/documentation
+- Canonical schema: `openapi.yaml` at the repository root — shipped with this plugin (two
+  directories up from this skill) and published at https://github.com/balancing-services/rest-api.
+  Always the final word on paths, parameters, response fields, nullability and enum values: read it
+  rather than guessing, and never invent a field name
+
+## Response shape
+
+Every endpoint returns the same envelope. For `/imbalance/prices`:
+
+```json
+{
+  "queriedPeriod": { "startAt": "2025-01-01T00:00:00Z", "endAt": "2025-01-02T00:00:00Z" },
+  "data": [
+    { "area": "EE", "eicCode": "10Y1001A1001A39I", "currency": "EUR", "direction": "positive",
+      "prices": [
+        { "period": { "startAt": "2025-01-01T00:00:00Z", "endAt": "2025-01-01T00:15:00Z" },
+          "pricePerMwh": 45.50 }
+      ] }
+  ],
+  "nextCursor": "v1:AAAAAYwBAgMEBQYHCAkKCw==",
+  "hasMore": true,
+  "nextUpdatedSince": "2025-01-02T09:15:00Z"
+}
+```
+
+`data` holds groups: the dimensions (area, reserve type, direction, currency, …) are stated once
+per group, and the inner array carries one entry per period. The inner array's name, value fields
+and exact group dimensions differ per endpoint — read them from the schema, never by analogy with
+another endpoint. (The `v1:` seen in the spec's cursor examples is not an API version — cursors
+are opaque.)
+
+## Endpoints
+
+All take `period-start-at` and `period-end-at`; the last column lists what else is required.
+
+| Endpoint | Returns | Also required |
+|---|---|---|
+| `GET /imbalance/prices` | Imbalance prices per MWh, grouped by direction (`positive`/`symmetric`/`negative`) | `area` |
+| `GET /imbalance/total-volumes` | Settled total imbalance volume as average power, direction `surplus`/`deficit`/`balanced` per period | `area` |
+| `GET /imbalance/total-volumes/current` | Experimental. Provisional open area control error at 1-minute resolution, roughly 25 min behind real time, ~90 days retained | `area` |
+| `GET /balancing/energy/activated-volumes` | Activated balancing energy as average power in MW, by direction and activation type | `area`, `reserve-type` |
+| `GET /balancing/energy/offered-volumes` | Offered balancing energy volumes | `area`, `reserve-type` |
+| `GET /balancing/energy/prices` | Balancing energy prices per MWh | `area`, `reserve-type` |
+| `GET /balancing/energy/bids` | Energy bid curves (`volumeInMw`, `pricePerMwh`), grouped by delivery period | `area`, `reserve-type` |
+| `GET /balancing/energy/demand` | Experimental. Balancing energy the TSO requested | `area`, `reserve-type` |
+| `GET /balancing/energy/satisfied-demand` | Experimental. The part of that demand which was satisfied | `area`, `reserve-type` |
+| `GET /balancing/energy/cross-border-marginal-prices` | Experimental. Cross-border purchased marginal prices per MWh | `area`, `reserve-type` |
+| `GET /balancing/energy/cross-border-volumes` | Balancing energy exchanged over one border, both directions, split by activation type | `area`, `other-area`, `reserve-type` |
+| `GET /balancing/capacity/bids` | Capacity bid curves grouped by delivery period; each bid carries its `procurement` and `status` (`offered`/`accepted`) | `area`, `reserve-type` |
+| `GET /balancing/capacity/prices` | Capacity prices per MW per hour, grouped per procurement | `area`, `reserve-type` |
+| `GET /balancing/capacity/procured-volumes` | Procured capacity in MW, grouped per procurement | `area`, `reserve-type` |
+| `GET /balancing/capacity/demand` | Experimental. Capacity the TSO set out to procure: `totalDemandInMw`, `localDemandInMw`, per procurement, with a `demandBasis` | `area`, `reserve-type` |
+| `GET /balancing/capacity/cross-zonal-allocation` | Allocated cross-zonal capacity over one border, both directions | `area`, `other-area`, `reserve-type` |
+| `GET /balancing/cross-border/available-capacity` | Capacity available for balancing energy exchange over one border, per direction | `area`, `other-area`, `reserve-type` |
+| `GET /energy/day-ahead/prices` | Experimental. Day-ahead wholesale prices per MWh in the zone's native currency | `area` |
+
+Endpoints marked experimental may change or be withdrawn without a deprecation period.
+`reserve-type` is one of `FCR`, `aFRR`, `mFRR`, `RR`.
+
+## Request semantics
+
+**Period window.** `period-start-at`/`period-end-at` are UTC ISO-8601 instants and both are
+required. Matching is by *overlap*, not containment: a record is returned when its own period
+overlaps the requested window, so a query that starts mid-period still returns that period's
+record in full. Compare against each record's own `period`, not the query bounds.
+
+**Areas.** `area` takes an area code from the `Area` enum in `openapi.yaml` — bidding zones and
+control areas (`EE`, `FI`, `DE`, `SE3`, `IT_NORTH`, …) plus aggregates: `BALTICS` (the Baltic LFC
+block that `EE`, `LV` and `LT` balance as one market), `IT` (Italy across its bidding zones) and
+`DE` alongside the four German TSO areas. Data exists only where the underlying source publishes
+it — an area/dataset combination with no data returns an empty `data` array, not an error. Do not
+treat empty as failure.
+
+**Pagination is always on.** Every endpoint accepts `cursor` and `limit` and every response
+carries `nextCursor` and `hasMore`. `limit` defaults to 100 (max 1000), except
+`/imbalance/total-volumes/current` (default 120, max 1440) and
+`/balancing/energy/cross-border-marginal-prices` (default 1000, max 10000). A request without
+pagination parameters returns the *first page*, not the whole window — follow `nextCursor` until
+`hasMore` is `false`, repeating every other query parameter unchanged on each page. Cursors are
+opaque: never parse or construct one.
+
+**Incremental polling.** Pass `updated-since` to get only the records that changed strictly after
+that timestamp, within the (still mandatory) period window. Every response carries `nextUpdatedSince`
+— feed exactly that value into the next poll over the same window; a timestamp you derive
+yourself can silently skip changes. The watermark deliberately lags, so consecutive polls overlap
+and a record can arrive more than once: upsert on consume.
+
+## Gotchas
+
+- **Bids are grouped by period.** `data[].periods[]` states the `period` once and carries that
+  period's `bids`. `limit` counts individual bids, so a page can end *inside* a period entry —
+  when `hasMore` is true, merge entries on the group's dimensions plus the period rather than
+  appending them. Bids within a period entry have no guaranteed order; sort by price yourself if
+  you need the merit order.
+- **Capacity data nests the procurement.** Capacity prices, procured volumes and demand carry a
+  required `procurement` object with `procuredAt` inside it (not a flat field), and each capacity
+  bid carries its own `procurement` — so one period entry can mix bids from several procurement
+  rounds. `procuredAt` distinguishes yearly from hourly auctions and re-runs; treat it as part of
+  the group key.
+- **`activationType` has four values.** `direct` and `scheduled` apply to mFRR; `unspecified` is
+  mFRR with no direct/scheduled breakdown published; `notApplicable` means the reserve type has no
+  activation-type concept at all (FCR, aFRR, RR). Do not collapse `unspecified` into
+  `notApplicable` — they answer different questions.
+- **Field names carry their units.** `volumeInMw`, `capacityInMw`, `averagePowerInMw`,
+  `pricePerMwh`, `pricePerMwPerHour`, `availableCapacityInMw`, `totalDemandInMw`,
+  `localDemandInMw`. There are no unit-less aliases on v2.
+- **Capacity demand can double-count.** Sum only `additive` demand across procurements of one
+  period; `substitutive` restates demand already covered by another procurement.
+- **Currency varies by area** (`EUR`, `BGN`, `CHF`, `HUF`, `PLN`, `RON`, `UAH`) and is stated per
+  group — never assume euros.
+
+## Quick start
+
+```bash
+curl -s "https://api.balancing.services/v2/imbalance/prices?area=EE&period-start-at=2025-01-01T00:00:00Z&period-end-at=2025-01-02T00:00:00Z&limit=1000" \
+  -H "Authorization: Bearer $BALANCING_SERVICES_TOKEN"
+```
+
+An official Python client is published as `balancing-services` (`pip install balancing-services`).
+It exposes one module per operation under `balancing_services.api.default`, and enum-typed
+parameters take plain strings (`area="EE"`). See `clients/python/README.md` in this repository.
+
+## References
+
+- Read `references/migrating-from-v1.md` when the user has existing v1 integration code, or
+  mentions v1, `/v1` URLs, or fields like `not_applicable`, `volume` or `price` without units.
+- Read `references/pagination-and-polling.md` before writing any pagination or polling loop.
+- Read `references/error-handling.md` when handling failures, retries or rate limits.

--- a/skills/balancing-services-api/references/error-handling.md
+++ b/skills/balancing-services-api/references/error-handling.md
@@ -1,0 +1,102 @@
+# Error handling
+
+## Problem body
+
+Errors come back as RFC 7807 Problem Details with content type `application/problem+json`:
+
+```json
+{
+  "type": "invalid-parameter",
+  "title": "Invalid Parameter",
+  "status": 400,
+  "detail": "The area parameter value is not valid"
+}
+```
+
+`type`, `title` and `status` are always present; `detail` is optional and describes the specific
+occurrence. `detail` is written for humans — log it, show it, but never branch on its wording.
+
+## Known `type` values
+
+| `type` | Status | Meaning | Retry? |
+|---|---|---|---|
+| `missing-parameter` | 400 | A required query parameter was not supplied | No — fix the request |
+| `invalid-parameter` | 400 | A parameter value is not valid (bad area, unparseable timestamp, `limit` out of range, malformed `cursor`) | No — fix the request |
+| `unauthorized` | 401 | Missing, malformed, expired or revoked token | No |
+| `forbidden` | 403 | The token is valid but does not permit access to the requested data | No |
+| `not-found` | 404 | The requested resource does not exist | No |
+| `rate-limited` | 429 | Request limit for the token exceeded | Yes — see below |
+| `not-implemented` | 501 | The feature is not available yet | No |
+| `internal-error` | 500 | Unexpected server-side failure | Yes, with backoff |
+
+**`type` is an open set.** New values may be introduced without a major-version bump. Match the
+values you handle explicitly and fall back on `status` for anything you do not recognise; an unknown
+`type` must never make the client raise. Do not generate a closed enum from it, and do not assert
+exhaustiveness in a `switch`/`when` over it.
+
+## Rate limiting
+
+A 429 response carries two headers documented in the spec:
+
+- `Retry-After` — seconds to wait before retrying.
+- `X-RateLimit-Limit` — the requests-per-minute allowance for your token.
+
+Honour `Retry-After` when present rather than inventing a delay. If it is absent, fall back to
+exponential backoff with jitter. Assume parallel workers sharing one token share one budget —
+either serialise the drain or cap concurrency.
+
+Rate limits are the usual reason a long drain fails part-way. Retry the failed page with the same
+cursor rather than restarting the drain.
+
+## Retry guidance
+
+Every endpoint is a read-only `GET`, so retries are always safe — there is nothing to make
+idempotent.
+
+Retry: 429 (per `Retry-After`), 500, and transport-level failures (connection resets, timeouts).
+Three or four attempts with exponential backoff and jitter is a reasonable ceiling; beyond that the
+problem is unlikely to clear on its own.
+
+Do not retry 400, 401, 403, 404 or 501 — the same request will fail the same way. Surface these with
+`type` and `detail` so the cause is visible.
+
+Two cases that look like errors but are not:
+
+- **An empty `data` array is a success.** Data exists only where the underlying source publishes
+  it: an area/dataset combination with no data returns 200 with `data: []`, not 404. Do not
+  escalate it.
+- **A rejected cursor is a client bug, not a transient fault.** Recover by restarting the drain
+  with no `cursor`; retrying the same cursor cannot succeed. A 400 does not machine-readably say
+  *which* parameter was bad (`detail` is not for branching), so use the request as the discriminator: if it
+  carried a `cursor`, restart the drain without one — at most once, so a genuinely bad parameter
+  still fails fast; if it did not, the request itself is wrong.
+
+## With the Python client
+
+`sync_detailed` (and its async counterpart) returns a response object carrying `status_code` and the
+parsed body, so error handling stays in normal control flow:
+
+```python
+response = get_imbalance_prices.sync_detailed(client=client, area="EE", ...)
+
+if response.status_code == 200:
+    handle(response.parsed)
+elif response.status_code == 429:
+    wait(int(response.headers.get("Retry-After", 5)))
+elif response.parsed is not None:
+    problem = response.parsed          # Problem model
+    log.error("%s (%s): %s", problem.title, problem.type, problem.detail)
+else:
+    # Undocumented status (a 502/503 from an intermediary, say): no Problem body was parsed
+    log.error("HTTP %s: %s", response.status_code, response.content)
+```
+
+On statuses the spec does not document, the generated client leaves `parsed` as `None` — fall back
+to `status_code` and the raw body rather than assuming a Problem model.
+
+`problem.type` is a plain string on v2 — compare it as a string, and keep a `status_code` fallback
+for unrecognised values. Setting `raise_on_unexpected_status=True` on the client makes undocumented
+status codes raise `UnexpectedStatus` instead of returning; leave it off if you prefer to branch on
+`status_code` yourself.
+
+See `clients/python/examples/error_handling.py` in this repository for a full retry example.

--- a/skills/balancing-services-api/references/migrating-from-v1.md
+++ b/skills/balancing-services-api/references/migrating-from-v1.md
@@ -1,0 +1,308 @@
+# Migrating a client from v1 to v2
+
+Version 1 remains served at `https://api.balancing.services/v1` and is unaffected by everything
+below, so the migration can be done at your own pace and rolled back by pointing the base URL
+back at `/v1`.
+
+## What changed, and why an unchanged client breaks
+
+v2 is the first major-version bump, and it spends that budget on four things: pagination everywhere,
+incremental polling, a response shape that states each dimension once instead of repeating it, and
+the removal of ambiguous names left over from 1.x.
+
+A v1 client repointed at `/v2` without changes typically fails in this order:
+
+1. **It silently truncates.** Endpoints that used to return the whole window now return the first
+   100 records. No error, no warning — just missing data, which is the failure mode most likely to
+   reach production unnoticed. Fix pagination first.
+2. **It cannot find its fields.** `volume`, `price`, `capacity` and `averagePowerMW` are gone; bids
+   moved a level deeper; `procuredAt` moved inside a `procurement` object.
+3. **It rejects enum values.** `activationType` no longer serves `not_applicable`, and serves a new
+   `unspecified`; `Problem.type` is no longer a closed set.
+4. **Two border endpoints reject the request outright** — 400, missing required `other-area`.
+
+Migrating in the order below keeps each step independently testable.
+
+## 1. Base path
+
+```
+- https://api.balancing.services/v1/imbalance/prices?area=EE&...
++ https://api.balancing.services/v2/imbalance/prices?area=EE&...
+```
+
+Paths, the `Authorization: Bearer` scheme, area codes, reserve types and the
+`period-start-at`/`period-end-at` overlap semantics are unchanged. Interactive docs move to
+`https://api.balancing.services/v2/documentation`.
+
+## 2. Pagination is always on
+
+On v1, pagination was piecemeal: endpoints added later in the 1.x line already paginated, while
+the original endpoints — imbalance prices and total volumes, activated volumes, energy and
+capacity prices, procured volumes, cross-zonal allocation — returned the complete window in one
+response (cross-border volumes sat in between, with an opt-in mode: see §10). On v2 every
+endpoint accepts `cursor` and `limit`, every response carries
+`nextCursor` and `hasMore`, and `limit` defaults to 100 (max 1000). Two endpoints keep wider
+bounds: `/imbalance/total-volumes/current` (default 120, max 1440) and
+`/balancing/energy/cross-border-marginal-prices` (default 1000, max 10000).
+
+Any code shaped like this is now wrong:
+
+```python
+# v1: one request, whole window
+response = get(url, params=params).json()
+for group in response["data"]:
+    ...
+```
+
+```python
+# v2: drain the pages
+cursor = None
+while True:
+    page = get(url, params={**params, "limit": 1000, **({"cursor": cursor} if cursor else {})}).json()
+    for group in page["data"]:
+        ...
+    if not page["hasMore"]:
+        break
+    cursor = page["nextCursor"]
+```
+
+Repeat every other query parameter unchanged on each page — the cursor carries the position, not
+the filters. See `pagination-and-polling.md` before writing the loop for real; the merge rules for
+grouped responses matter.
+
+Responses also gained a required `nextUpdatedSince` field, the watermark for the new optional
+`updated-since` parameter. Nothing needs to consume it to migrate, but note the reverse direction:
+a *v2* client pointed at `/v1` fails, because v1 responses have no `nextUpdatedSince`.
+
+## 3. Bids are grouped by delivery period
+
+Both bid endpoints (`/balancing/energy/bids`, `/balancing/capacity/bids`) previously carried a flat
+`bids` array in which every bid repeated its own `period`. v2 states the period once:
+
+```json
+// v1
+{ "area": "EE", "eicCode": "10Y1001A1001A39I", "reserveType": "mFRR", "direction": "up", "currency": "EUR", "standardProduct": true,
+  "bids": [
+    { "period": { "startAt": "2025-01-01T00:00:00Z", "endAt": "2025-01-01T01:00:00Z" }, "volumeInMw": 100, "pricePerMwh": 55.25 },
+    { "period": { "startAt": "2025-01-01T00:00:00Z", "endAt": "2025-01-01T01:00:00Z" }, "volumeInMw": 40,  "pricePerMwh": 61.00 }
+  ] }
+```
+
+```json
+// v2
+{ "area": "EE", "eicCode": "10Y1001A1001A39I", "reserveType": "mFRR", "direction": "up", "currency": "EUR", "standardProduct": true,
+  "periods": [
+    { "period": { "startAt": "2025-01-01T00:00:00Z", "endAt": "2025-01-01T01:00:00Z" },
+      "bids": [
+        { "volumeInMw": 100, "pricePerMwh": 55.25 },
+        { "volumeInMw": 40,  "pricePerMwh": 61.00 }
+      ] }
+  ] }
+```
+
+Period entries ascend by period start within a group. Bids inside an entry carry no guaranteed
+order — sort by price if you need the merit order.
+
+`limit` still counts individual bids, so a page can end in the middle of a period entry. When
+`hasMore` is `true`, accumulate by merging on the group's dimensions plus the period; appending
+period entries blindly produces two entries for the same period with the bid curve split between
+them.
+
+## 4. `procuredAt` moved into a `procurement` object
+
+Affects `/balancing/capacity/prices`, `/balancing/capacity/procured-volumes` and
+`/balancing/capacity/demand`. On prices and procured volumes `procuredAt` was also experimental and
+nullable in v1; in v2 `procurement` is required and stable, so null-handling branches can go.
+
+```json
+// v1
+{ "area": "FI", "eicCode": "10YFI-1--------U", "reserveType": "aFRR", "direction": "up", "currency": "EUR",
+  "procuredAt": "2024-08-15T14:30:00Z",
+  "prices": [ ... ] }
+```
+
+```json
+// v2
+{ "area": "FI", "eicCode": "10YFI-1--------U", "reserveType": "aFRR", "direction": "up", "currency": "EUR",
+  "procurement": { "procuredAt": "2024-08-15T14:30:00Z" },
+  "prices": [ ... ] }
+```
+
+Capacity bids gained the same object, one level deeper — each bid states the procurement it was
+submitted to, so a single period entry can mix bids from several procurement rounds:
+
+```json
+// v2 /balancing/capacity/bids
+{ "period": { "startAt": "...", "endAt": "..." },
+  "bids": [
+    { "capacityInMw": 50, "pricePerMwPerHour": 12.50, "status": "accepted",
+      "procurement": { "procuredAt": "2024-08-15T14:30:00Z" } }
+  ] }
+```
+
+If your storage keys capacity rows on `(area, reserveType, direction, period)`, add the procurement
+to the key.
+
+## 5. `other-area` is now required on two border endpoints
+
+`/balancing/energy/cross-border-volumes` and `/balancing/capacity/cross-zonal-allocation`
+previously took `area` alone and returned data across *all* borders of that area. v2 requires both
+ends:
+
+```
+- GET /v1/balancing/energy/cross-border-volumes?area=FI&reserve-type=mFRR&period-start-at=...
++ GET /v2/balancing/energy/cross-border-volumes?area=FI&other-area=EE&reserve-type=mFRR&period-start-at=...
+```
+
+Results still cover both directions of that border (area → other-area and other-area → area), and
+each record names them in `fromArea`/`toArea`. A request where `area` equals `other-area` is
+rejected with 400.
+
+If your client relied on the all-borders behaviour, enumerate the borders you care about and issue
+one request per border. `/balancing/cross-border/available-capacity` already required `other-area`
+on v1 and is unchanged.
+
+## 6. Cross-zonal allocation is no longer expanded onto a sub-period grid
+
+`/balancing/capacity/cross-zonal-allocation` returns the allocation records as published, grouped
+by border, reserve type and period duration. v1 expanded them onto a common sub-period grid,
+splitting one allocation into several equal-valued entries.
+
+Consequences: one border can now yield several groups within one query when its allocations differ
+in period duration. Periods within a group all share that group's duration, but durations differ
+across groups, and none are sub-divided onto a common grid any more. Read each record's own
+`period` and normalise client-side if your model needs a fixed grid.
+
+## 7. `activationType` renames, and gains `unspecified`
+
+| v1 value | v2 value |
+|---|---|
+| `direct` | `direct` |
+| `scheduled` | `scheduled` |
+| `not_applicable` (FCR, aFRR, RR) | `notApplicable` |
+| `not_applicable` (mFRR with no direct/scheduled breakdown) | `unspecified` |
+
+Two changes at once. The rename to camelCase removes the API's only snake_case enum value. The
+split is the substantive one: `notApplicable` now means only "this reserve type has no
+activation-type concept", while mFRR records whose source publishes no direct/scheduled breakdown
+report `unspecified`. Code that treated `not_applicable` as "not mFRR" will misclassify those mFRR
+records unless it handles `unspecified` separately.
+
+Since only mFRR distinguishes activation types, the split settles per query: a call filtered to
+`reserve-type=mFRR` can only return `direct`, `scheduled` or `unspecified`, and a call for FCR,
+aFRR or RR only `notApplicable`. A v1 call site that filtered on `not_applicable` therefore maps
+to exactly one of the new values — which one depends only on the reserve type it queries.
+
+Affects `/balancing/energy/prices`, `/balancing/energy/activated-volumes`,
+`/balancing/energy/offered-volumes`, `/balancing/energy/demand`,
+`/balancing/energy/satisfied-demand` and `/balancing/energy/cross-border-volumes`. Clients that
+parse the enum strictly must accept both new values.
+
+## 8. `Problem.type` is an open string
+
+The error body's `type` was a closed enum in v1 and is a plain string in v2. Generated clients that
+exposed it as an enum type now expose a string, so `problem.type.value` and enum-member comparisons
+need rewriting.
+
+The wire values are otherwise unchanged: `missing-parameter`, `invalid-parameter`, `unauthorized`,
+`forbidden`, `not-found`, `rate-limited`, `not-implemented`, `internal-error`. This also fixes an
+omission — v1's enum lacked `not-found`, which 404 responses already returned, so strict clients
+could fail to parse a well-formed 404.
+
+Match the values you handle and fall back on `status` for anything else; new types may appear
+without a major-version bump. See `error-handling.md`.
+
+## 9. Unit-less fields removed
+
+Deprecated in 1.14.0, removed in 2.0.0. Every explicit-unit name below already exists on v1, so
+this step can be done *before* switching base URLs and verified against v1.
+
+| Where | v1 field (removed) | v2 field |
+|---|---|---|
+| Imbalance prices — `data[].prices[]` | `price` | `pricePerMwh` |
+| Imbalance total volumes (incl. `/current`) — `data[].volumes[]` | `averagePowerMW` | `averagePowerInMw` |
+| Balancing energy volumes (activated, offered, demand, satisfied demand, cross-border) — `data[].volumes[]` | `volume` | `volumeInMw` |
+| Balancing energy prices — `data[].prices[]` | `price` | `pricePerMwh` |
+| Energy bids | `volume`, `price` | `volumeInMw`, `pricePerMwh` |
+| Capacity bids | `capacity`, `price` | `capacityInMw`, `pricePerMwPerHour` |
+| Capacity prices — `data[].prices[]` | `price` | `pricePerMwPerHour` |
+| Capacity procured volumes, cross-zonal allocation — `data[].volumes[]` | `volume` | `volumeInMw` |
+| Day-ahead prices — `data[].prices[]` | `price` | `pricePerMwh` |
+| Cross-border marginal prices — `data[].prices[]` | `price` | `pricePerMwh` |
+
+Capacity demand (`totalDemandInMw`, `localDemandInMw`) and cross-border available capacity
+(`availableCapacityInMw`) never had unit-less names.
+
+## 10. Non-paginated mode and the 32-day cap are gone
+
+`/balancing/energy/cross-border-volumes` had an opt-in pagination mode: omitting both `cursor` and
+`limit` returned the full result set in one response, bounded to a 32-day period. That mode is
+removed, as announced when it was deprecated in 1.x. Pagination is now always on — and, with it,
+the 32-day cap is gone, so arbitrarily long windows can be drained page by page.
+
+## 11. Python client: `Enum` → `Literal`
+
+The official `balancing-services` client generates `Literal[...]` string types instead of `Enum`
+classes for `Area`, `ReserveType`, `ActivationType`, `Currency`, `Direction`, `EicCode`,
+`BidStatus`, `ImbalanceDirection`, `TotalImbalanceDirection` and `DemandBasis`.
+
+```python
+# before
+from balancing_services.models import Area, ReserveType
+response = get_balancing_energy_prices.sync_detailed(
+    client=client, area=Area.EE, reserve_type=ReserveType.MFRR, ...
+)
+print(response.parsed.data[0].area.value)
+```
+
+```python
+# after
+response = get_balancing_energy_prices.sync_detailed(
+    client=client, area="EE", reserve_type="mFRR", ...
+)
+print(response.parsed.data[0].area)
+```
+
+Enum-member access (`Area.EE`, `EicCode.VALUE_19`) and the `.value` accessor on those model fields
+are gone. The upside is stability: a `Literal` has no positional member names, so adding or
+reordering values in the spec can no longer silently rebind `EicCode.VALUE_19` to a different code
+between releases.
+
+## Migration checklist
+
+Walk this against the customer's codebase, in order.
+
+- [ ] **Base URL.** Grep for `api.balancing.services/v1`, `/v1/`, and any hardcoded path built from
+      a version constant. Confirm there is exactly one place the version is set.
+- [ ] **Pagination.** For every call site, confirm the response is drained: `hasMore` is checked and
+      `nextCursor` is passed back, with all other parameters repeated. Flag any call that reads
+      `data` once and moves on — including ones that "worked" on v1 because the endpoint was
+      unpaginated. Watch for pipelines that assume a whole window in one payload (dataframe loads,
+      bulk upserts, "row count equals expected periods" assertions).
+- [ ] **`other-area`.** Every call to `/balancing/energy/cross-border-volumes` and
+      `/balancing/capacity/cross-zonal-allocation` must pass it. Where the old all-borders
+      behaviour was used, replace with an explicit list of borders.
+- [ ] **Bid parsing.** Grep for `["bids"]`, `.bids` and any model with `bids` at group level.
+      Rewrite as `periods[].bids[]`, take the period from the entry, and merge cross-page entries on
+      group dimensions plus period.
+- [ ] **Field names.** Grep for `"volume"`, `"price"`, `"capacity"`, `"averagePowerMW"` as exact
+      keys or attribute names and apply the mapping table. Beware ORM columns, chart series names
+      and CSV headers that happen to share the names.
+- [ ] **`procuredAt`.** Grep for it; rewrite to `procurement.procuredAt`, add it to capacity bid
+      parsing, and drop null-handling on capacity prices and procured volumes. Extend any storage
+      key that identifies a capacity row without the procurement.
+- [ ] **`activationType`.** Grep for `not_applicable`. Decide, per site, whether it meant "no
+      activation-type concept" (`notApplicable`) or "any mFRR without a breakdown"
+      (`unspecified` too). Make the parse non-strict or add both values.
+- [ ] **Cross-zonal allocation.** If the client assumed uniform period lengths or one group per
+      border, handle mixed durations and multiple groups.
+- [ ] **Error handling.** Replace enum comparisons on `Problem.type` with string comparison plus a
+      `status` fallback; make sure an unknown `type` does not raise.
+- [ ] **Python client.** Upgrade `balancing-services`, replace `Area.EE`-style members with plain
+      strings, and remove `.value` on enum-typed model fields.
+- [ ] **Optional: incremental polling.** If the client re-downloads a fixed window on a schedule,
+      switch it to `updated-since` with the `nextUpdatedSince` watermark. See
+      `pagination-and-polling.md`.
+- [ ] **Verify.** Re-run one representative query per endpoint against `/v1` and `/v2` over the same
+      window and reconcile record counts and values. Truncated pagination is the failure this
+      catches.

--- a/skills/balancing-services-api/references/pagination-and-polling.md
+++ b/skills/balancing-services-api/references/pagination-and-polling.md
@@ -1,0 +1,132 @@
+# Pagination and incremental polling
+
+Read this before writing a loop against the API. Every v2 endpoint is paginated, and the two most
+common bugs — silently truncating a window, and skipping a change while polling — both come from
+short-cutting the contract below.
+
+## Pagination contract
+
+Request parameters, accepted by every endpoint:
+
+| Parameter | Required | Notes |
+|---|---|---|
+| `cursor` | no | The `nextCursor` of the previous page. Omit for the first page |
+| `limit` | no | Page size. Default 100, max 1000 unless noted below |
+
+Two endpoints have their own bounds, sized to their resolution:
+
+| Endpoint | Default `limit` | Max `limit` |
+|---|---|---|
+| `/imbalance/total-volumes/current` | 120 | 1440 (one day of per-minute values) |
+| `/balancing/energy/cross-border-marginal-prices` | 1000 | 10000 |
+
+Every response carries:
+
+- `hasMore` — `true` while further pages exist.
+- `nextCursor` — opaque string to pass as `cursor` on the next request; `null` on the last page.
+- `queriedPeriod` — the window you asked for, echoed back.
+- `nextUpdatedSince` — the polling watermark (see below). Always present, even when `data` is empty.
+
+Rules that are easy to get wrong:
+
+- **A request without `cursor` and `limit` returns the first page, not the whole window.** There is
+  no mode that returns everything in one response.
+- **Repeat every other query parameter unchanged on each page.** The cursor carries the position
+  only; `area`, `reserve-type`, the period bounds and `updated-since` must be resent identically.
+- **Cursors are opaque.** Never parse, construct, truncate or reuse one across endpoints. If a
+  cursor is rejected, recover by restarting the drain with no cursor.
+- **Drive the loop off `hasMore`, not off `len(data)`.** A page can be shorter than `limit` and
+  still have successors, and `data` counts *groups*, not records.
+
+### Merging grouped responses across pages
+
+`data` holds groups (area, reserve type, direction, currency, …) with the periods nested inside, and
+that grouping is applied *per page*. A group whose records straddle a page boundary can appear on
+both pages. Accumulate by merging on the group's dimensions — appending groups blindly can yield two
+entries for the same series.
+
+For the bid endpoints (`/balancing/energy/bids`, `/balancing/capacity/bids`) there is one more
+level: `limit` counts **individual bids**, not groups or period entries, so a page can end in the
+middle of a delivery period. When `hasMore` is `true`, treat the last period entry as incomplete and
+merge on the group's dimensions **plus** the period. Bids inside an entry have no guaranteed order —
+sort by price yourself for the merit order.
+
+`/balancing/capacity/cross-zonal-allocation` groups by border, reserve type and period duration, so
+one border can appear as several groups in one drain when its allocations differ in length.
+
+### Draining a window
+
+```python
+def drain(session, url, params, limit=1000):
+    cursor = None
+    while True:
+        response = session.get(url, params={**params, "limit": limit,
+                                            **({"cursor": cursor} if cursor else {})})
+        # Error handling elided: retry 429 per Retry-After and 5xx with backoff, surface
+        # the Problem body otherwise — see error-handling.md. Retry a failed page with the
+        # same cursor rather than restarting the drain.
+        page = response.json()
+        yield page
+        if not page["hasMore"]:
+            return
+        cursor = page["nextCursor"]
+```
+
+Page size is a throughput/latency trade-off: 10–50 for interactive UIs, 100–500 as a default,
+500–1000 for batch loads. To resume after a crash mid-drain, checkpoint the last `nextCursor`
+alongside the data you have written.
+
+## Incremental polling with `updated-since`
+
+`updated-since` narrows a query to the records whose stored value changed strictly after the given
+timestamp, *in addition to* the mandatory period window. It is not a global change feed: the window
+still bounds the query, so polling means "re-ask for this window, but only the changes".
+
+Records carry no per-record change timestamp. Instead, every response reports `nextUpdatedSince` —
+the watermark to feed into the next poll. It comes from the server, so your clock never enters the
+loop.
+
+Contract:
+
+- Every page of one drain reports the **same** `nextUpdatedSince`. Read it once (any page will do)
+  and store it after the drain completes.
+- **Pass back exactly that value** on the next poll over the same window. A timestamp you derive
+  yourself — for instance the newest period you saw, or "now" — sits ahead of the point the drain is
+  actually complete to, and can silently skip changes.
+- The watermark deliberately lags real time, so consecutive polls overlap slightly and a record can
+  be delivered more than once. **Delivery is at-least-once: upsert on consume.** Duplicates are the
+  designed-for cost; a lost change is not tolerated, which is why the lag exists.
+- Do not mix cursors between polls; each poll is its own drain, restarted from your stored
+  watermark.
+
+### Recipe
+
+1. Drain the window with no `updated-since`, following `nextCursor` until `hasMore` is `false`. Keep
+   the response's `nextUpdatedSince`.
+2. On the next poll, pass that value as `updated-since` and drain all pages again. An empty `data`
+   array means nothing changed.
+3. Replace the stored watermark with the new `nextUpdatedSince` and repeat.
+
+Persist the watermark wherever you persist the data, ideally in the same transaction. On restart,
+resuming from the last stored watermark re-delivers a little and loses nothing.
+
+```python
+def poll(session, url, params, store, watermark=None):
+    """One poll cycle. Returns the watermark to use next time."""
+    poll_params = dict(params)
+    if watermark:
+        poll_params["updated-since"] = watermark
+
+    next_watermark = watermark
+    for page in drain(session, url, poll_params):
+        for group in page["data"]:
+            store.upsert(group)          # idempotent: records may repeat across polls
+        next_watermark = page["nextUpdatedSince"]   # same value on every page of one drain
+
+    store.save_watermark(next_watermark)  # same transaction as the upserts, ideally
+    return next_watermark
+```
+
+When merging a filtered response into stored data, merge records by period rather than by group
+identity — a filtered response carries only the records that changed, so its groups need not line
+up one-to-one with the groups of a full drain.


### PR DESCRIPTION
The repository doubles as a Claude Code plugin marketplace containing
itself as its single plugin, so the skill installs with two commands.
The skill teaches an agent the endpoint catalogue, pagination and
updated-since polling contracts, and error handling, and carries a
change-by-change v1-to-v2 migration guide with a checklist.
bump-version.sh now also stamps the plugin manifest so the plugin
version tracks openapi.yaml.
