### PR TITLE
Restate the bid endpoints' updated-since contract at bid-set granularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Claude Code skill (`skills/balancing-services-api/`) covering both integrating with the API and migrating an existing client from v1 to v2. It describes the endpoint catalogue and request semantics, the cursor-pagination and `updated-since` polling contracts, and RFC 7807 error handling, and carries a change-by-change v1 → v2 migration guide with before/after payloads and a checklist to walk against a client codebase
 - The repository doubles as a Claude Code plugin marketplace containing itself as its single plugin (`.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`), so the skill installs with `/plugin marketplace add balancing-services/rest-api` followed by `/plugin install balancing-services-rest-api@balancing-services`; see the README for preconfiguring it for a team. The plugin version tracks `openapi.yaml`'s `info.version` and is stamped by `scripts/bump-version.sh`
 
+### Changed
+- The bid endpoints' descriptions now state the `updated-since` polling contract at bid-set granularity: change is tracked per stored bid set rather than per bid, so a changed set is re-delivered with its unchanged bids included, and a filtered response is not guaranteed to carry a period's complete bid set — re-fetch without `updated-since` to reconcile withdrawals. The shipped skill's polling guidance is restated to match and now covers bid withdrawals (a withdrawn bid is deleted without replacement; no response ever names it). Documentation only; no wire or behaviour change in the spec's schemas
+
 ## [2.0.2] - 2026-07-25
 
 ### Fixed

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -299,8 +299,12 @@ paths:
         true the last period entry may continue on the next page, so merge entries on their group's
         dimensions plus the period when accumulating pages. Bids within a period entry are returned in no
         guaranteed order — sort by price client-side if you need the merit order. When polling with
-        `updated-since`, a page holds only the bids that changed, so the period entries of a poll are not
-        necessarily contiguous.
+        `updated-since`, change is tracked per stored bid set rather than per bid: a changed set is
+        re-delivered with its unchanged bids included, so the period entries of a poll are not
+        necessarily contiguous. A period entry may span more than one tracked set, and a set that
+        changes again mid-drain is deferred to the next poll, so a filtered response is not guaranteed
+        to carry a period's complete bid set — re-fetch without `updated-since` to reconcile
+        withdrawals.
       operationId: getBalancingEnergyBids
       parameters:
         - $ref: '#/components/parameters/area'
@@ -459,8 +463,12 @@ paths:
         true the last period entry may continue on the next page, so merge entries on their group's
         dimensions plus the period when accumulating pages. Bids within a period entry are returned in no
         guaranteed order — sort by price client-side if you need the merit order. When polling with
-        `updated-since`, a page holds only the bids that changed, so the period entries of a poll are not
-        necessarily contiguous.
+        `updated-since`, change is tracked per stored bid set rather than per bid — each procurement
+        round of a period is its own set: a changed set is re-delivered with its unchanged bids
+        included, so the period entries of a poll are not necessarily contiguous. A period entry may
+        span more than one set, and a set that changes again mid-drain is deferred to the next poll,
+        so a filtered response is not guaranteed to carry a period's complete bid set — re-fetch
+        without `updated-since` to reconcile withdrawals.
       operationId: getBalancingCapacityBids
       parameters:
         - $ref: '#/components/parameters/area'

--- a/skills/balancing-services-api/SKILL.md
+++ b/skills/balancing-services-api/SKILL.md
@@ -97,7 +97,11 @@ opaque: never parse or construct one.
 that timestamp, within the (still mandatory) period window. Every response carries `nextUpdatedSince`
 — feed exactly that value into the next poll over the same window; a timestamp you derive
 yourself can silently skip changes. The watermark deliberately lags, so consecutive polls overlap
-and a record can arrive more than once: upsert on consume.
+and a record can arrive more than once: upsert on consume. On the bid endpoints the unit of change
+is a stored bid set, not an individual bid: any change re-delivers all of the set's bids, unchanged
+ones included, and since bids carry no client-visible identifier there is no key to upsert on —
+replace per set, and re-fetch without `updated-since` when exactness matters (see
+references/pagination-and-polling.md).
 
 ## Gotchas
 

--- a/skills/balancing-services-api/references/pagination-and-polling.md
+++ b/skills/balancing-services-api/references/pagination-and-polling.md
@@ -80,7 +80,8 @@ alongside the data you have written.
 
 `updated-since` narrows a query to the records whose stored value changed strictly after the given
 timestamp, *in addition to* the mandatory period window. It is not a global change feed: the window
-still bounds the query, so polling means "re-ask for this window, but only the changes".
+still bounds the query, so polling means "re-ask for this window, but only the changes". On the bid
+endpoints change is tracked per bid set rather than per record — see below.
 
 Records carry no per-record change timestamp. Instead, every response reports `nextUpdatedSince` —
 the watermark to feed into the next poll. It comes from the server, so your clock never enters the
@@ -96,6 +97,16 @@ Contract:
 - The watermark deliberately lags real time, so consecutive polls overlap slightly and a record can
   be delivered more than once. **Delivery is at-least-once: upsert on consume.** Duplicates are the
   designed-for cost; a lost change is not tolerated, which is why the lag exists.
+- On the bid endpoints the unit of change is a **bid set** — the bids stored and tracked together
+  for one delivery period — not an individual bid: any change to a set (a new bid, a revised one, a
+  withdrawal) re-delivers all of the set's bids, including the ones that did not change themselves.
+  A period entry in a response is not always a single set — capacity bids procured in separate
+  rounds are separate sets, as are distinctions the response's grouping does not surface — so a
+  re-delivered set does not imply the period entry around it is complete. And since bids carry no
+  client-visible identifier, there is no key to upsert on: a filtered poll tells you a set changed
+  and hands you its current bids, but not which bid was added, revised, or withdrawn — it cannot
+  maintain an exact bid-level mirror on its own. When exactness matters, reconcile with an
+  unfiltered re-fetch (see below).
 - Do not mix cursors between polls; each poll is its own drain, restarted from your stored
   watermark.
 
@@ -120,7 +131,7 @@ def poll(session, url, params, store, watermark=None):
     next_watermark = watermark
     for page in drain(session, url, poll_params):
         for group in page["data"]:
-            store.upsert(group)          # idempotent: records may repeat across polls
+            store.upsert(group)          # idempotent: records may repeat across polls; bids: replace per set
         next_watermark = page["nextUpdatedSince"]   # same value on every page of one drain
 
     store.save_watermark(next_watermark)  # same transaction as the upserts, ideally
@@ -128,5 +139,17 @@ def poll(session, url, params, store, watermark=None):
 ```
 
 When merging a filtered response into stored data, merge records by period rather than by group
-identity — a filtered response carries only the records that changed, so its groups need not line
-up one-to-one with the groups of a full drain.
+identity — a filtered response carries only what changed (for bids, only the changed sets, each
+delivered whole), so its groups need not line up one-to-one with the groups of a full drain.
+
+### Withdrawals and the unfiltered re-fetch
+
+A poller only sees rows that exist. Bids are the one dataset where deletion is normal operation: a
+bid withdrawn at the source is deleted here without replacement, and no response ever names it.
+
+The withdrawal does move its bid set's change time, so the set's *surviving* bids are re-delivered.
+That narrows the blind spot but does not close it: a set whose bids were all withdrawn has no
+survivors to re-deliver, a period entry can span several independently-tracked sets, and a set that
+changes mid-drain defers its remaining bids to the next poll — so a filtered poll is not guaranteed
+to carry a period's complete bid set. If bid-level accuracy matters, periodically re-fetch the full
+window without `updated-since` and reconcile.


### PR DESCRIPTION
The v2 bid polls track change per stored bid set rather than per bid: a
changed set is re-delivered with its unchanged bids included, a set that
changes mid-drain is deferred to the next poll, and a filtered response
is not guaranteed to carry a period's complete bid set — clients re-fetch
without updated-since to reconcile withdrawals. Mirrors the internal
spec's endpoint-description wording verbatim, and restates the shipped
skill's polling guidance to match, adding the previously undocumented
withdrawal limitation (a withdrawn bid is deleted without replacement;
no response ever names it). Documentation only, no schema change.
