### PR TITLE
Add the experimental imbalance price forecast endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Experimental imbalance price forecast endpoint (`/imbalance/prices/forecast`), serving forecasts of the imbalance price — see the endpoint description for the semantics
 - Claude Code skill (`skills/balancing-services-api/`) covering both integrating with the API and migrating an existing client from v1 to v2. It describes the endpoint catalogue and request semantics, the cursor-pagination and `updated-since` polling contracts, and RFC 7807 error handling, and carries a change-by-change v1 → v2 migration guide with before/after payloads and a checklist to walk against a client codebase
 - The repository doubles as a Claude Code plugin marketplace containing itself as its single plugin (`.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`), so the skill installs with `/plugin marketplace add balancing-services/rest-api` followed by `/plugin install balancing-services-rest-api@balancing-services`; see the README for preconfiguring it for a team. The plugin version tracks `openapi.yaml`'s `info.version` and is stamped by `scripts/bump-version.sh`
 

--- a/clients/python/balancing_services/api/default/get_balancing_capacity_bids.py
+++ b/clients/python/balancing_services/api/default/get_balancing_capacity_bids.py
@@ -145,8 +145,12 @@ def sync_detailed(
     true the last period entry may continue on the next page, so merge entries on their group's
     dimensions plus the period when accumulating pages. Bids within a period entry are returned in no
     guaranteed order — sort by price client-side if you need the merit order. When polling with
-    `updated-since`, a page holds only the bids that changed, so the period entries of a poll are not
-    necessarily contiguous.
+    `updated-since`, change is tracked per stored bid set rather than per bid — each procurement
+    round of a period is its own set: a changed set is re-delivered with its unchanged bids
+    included, so the period entries of a poll are not necessarily contiguous. A period entry may
+    span more than one set, and a set that changes again mid-drain is deferred to the next poll,
+    so a filtered response is not guaranteed to carry a period's complete bid set — re-fetch
+    without `updated-since` to reconcile withdrawals.
 
     Args:
         area (Area): Area code
@@ -209,8 +213,12 @@ def sync(
     true the last period entry may continue on the next page, so merge entries on their group's
     dimensions plus the period when accumulating pages. Bids within a period entry are returned in no
     guaranteed order — sort by price client-side if you need the merit order. When polling with
-    `updated-since`, a page holds only the bids that changed, so the period entries of a poll are not
-    necessarily contiguous.
+    `updated-since`, change is tracked per stored bid set rather than per bid — each procurement
+    round of a period is its own set: a changed set is re-delivered with its unchanged bids
+    included, so the period entries of a poll are not necessarily contiguous. A period entry may
+    span more than one set, and a set that changes again mid-drain is deferred to the next poll,
+    so a filtered response is not guaranteed to carry a period's complete bid set — re-fetch
+    without `updated-since` to reconcile withdrawals.
 
     Args:
         area (Area): Area code
@@ -268,8 +276,12 @@ async def asyncio_detailed(
     true the last period entry may continue on the next page, so merge entries on their group's
     dimensions plus the period when accumulating pages. Bids within a period entry are returned in no
     guaranteed order — sort by price client-side if you need the merit order. When polling with
-    `updated-since`, a page holds only the bids that changed, so the period entries of a poll are not
-    necessarily contiguous.
+    `updated-since`, change is tracked per stored bid set rather than per bid — each procurement
+    round of a period is its own set: a changed set is re-delivered with its unchanged bids
+    included, so the period entries of a poll are not necessarily contiguous. A period entry may
+    span more than one set, and a set that changes again mid-drain is deferred to the next poll,
+    so a filtered response is not guaranteed to carry a period's complete bid set — re-fetch
+    without `updated-since` to reconcile withdrawals.
 
     Args:
         area (Area): Area code
@@ -330,8 +342,12 @@ async def asyncio(
     true the last period entry may continue on the next page, so merge entries on their group's
     dimensions plus the period when accumulating pages. Bids within a period entry are returned in no
     guaranteed order — sort by price client-side if you need the merit order. When polling with
-    `updated-since`, a page holds only the bids that changed, so the period entries of a poll are not
-    necessarily contiguous.
+    `updated-since`, change is tracked per stored bid set rather than per bid — each procurement
+    round of a period is its own set: a changed set is re-delivered with its unchanged bids
+    included, so the period entries of a poll are not necessarily contiguous. A period entry may
+    span more than one set, and a set that changes again mid-drain is deferred to the next poll,
+    so a filtered response is not guaranteed to carry a period's complete bid set — re-fetch
+    without `updated-since` to reconcile withdrawals.
 
     Args:
         area (Area): Area code

--- a/clients/python/balancing_services/api/default/get_imbalance_price_forecasts.py
+++ b/clients/python/balancing_services/api/default/get_imbalance_price_forecasts.py
@@ -7,9 +7,8 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.area import Area
-from ...models.balancing_energy_bids_response import BalancingEnergyBidsResponse
+from ...models.imbalance_price_forecasts_response import ImbalancePriceForecastsResponse
 from ...models.problem import Problem
-from ...models.reserve_type import ReserveType
 from ...types import UNSET, Response, Unset
 
 
@@ -18,7 +17,6 @@ def _get_kwargs(
     area: Area,
     period_start_at: datetime.datetime,
     period_end_at: datetime.datetime,
-    reserve_type: ReserveType,
     cursor: str | Unset = UNSET,
     limit: int | Unset = 100,
     updated_since: datetime.datetime | Unset = UNSET,
@@ -35,9 +33,6 @@ def _get_kwargs(
     json_period_end_at = period_end_at.isoformat()
     params["period-end-at"] = json_period_end_at
 
-    json_reserve_type: str = reserve_type
-    params["reserve-type"] = json_reserve_type
-
     params["cursor"] = cursor
 
     params["limit"] = limit
@@ -51,7 +46,7 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/balancing/energy/bids",
+        "url": "/imbalance/prices/forecast",
         "params": params,
     }
 
@@ -60,9 +55,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> BalancingEnergyBidsResponse | Problem | None:
+) -> ImbalancePriceForecastsResponse | Problem | None:
     if response.status_code == 200:
-        response_200 = BalancingEnergyBidsResponse.from_dict(response.json())
+        response_200 = ImbalancePriceForecastsResponse.from_dict(response.json())
 
         return response_200
 
@@ -109,7 +104,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[BalancingEnergyBidsResponse | Problem]:
+) -> Response[ImbalancePriceForecastsResponse | Problem]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -124,38 +119,23 @@ def sync_detailed(
     area: Area,
     period_start_at: datetime.datetime,
     period_end_at: datetime.datetime,
-    reserve_type: ReserveType,
     cursor: str | Unset = UNSET,
     limit: int | Unset = 100,
     updated_since: datetime.datetime | Unset = UNSET,
-) -> Response[BalancingEnergyBidsResponse | Problem]:
-    """Get balancing energy bids
+) -> Response[ImbalancePriceForecastsResponse | Problem]:
+    """Get imbalance price forecasts for an area
 
-     Returns balancing energy bids for the specified area within the given time period. Prices are in
-    the specified currency per MWh.
+     **Experimental** - This endpoint is under active development and may change without notice.
 
-    Bids are grouped by their shared dimensions (area, reserve type, direction, currency,
-    standard-product flag), and inside each group by delivery period: each entry of `periods` states
-    the period once and carries that period's bids. Period entries ascend by period start within
-    their group.
-
-    Supports cursor-based pagination for large result sets; `limit` counts individual bids, not
-    groups or period entries. Groups and period entries are assembled per page: when `hasMore` is
-    true the last period entry may continue on the next page, so merge entries on their group's
-    dimensions plus the period when accumulating pages. Bids within a period entry are returned in no
-    guaranteed order — sort by price client-side if you need the merit order. When polling with
-    `updated-since`, change is tracked per stored bid set rather than per bid: a changed set is
-    re-delivered with its unchanged bids included, so the period entries of a poll are not
-    necessarily contiguous. A period entry may span more than one tracked set, and a set that
-    changes again mid-drain is deferred to the next poll, so a filtered response is not guaranteed
-    to carry a period's complete bid set — re-fetch without `updated-since` to reconcile
-    withdrawals.
+    Returns imbalance price forecasts for the specified area within the given time period. Each
+    forecast is a predictive distribution: level/price pairs in `quantiles`, ascending by level.
+    An area without forecast coverage returns an empty result rather than an error. Supports
+    cursor-based pagination for large result sets.
 
     Args:
         area (Area): Area code
         period_start_at (datetime.datetime):  Example: 2025-01-01T00:00:00Z.
         period_end_at (datetime.datetime):  Example: 2025-01-02T00:00:00Z.
-        reserve_type (ReserveType): Reserve type
         cursor (str | Unset):  Example: v1:AAAAAYwBAgMEBQYHCAkKCw==.
         limit (int | Unset):  Default: 100. Example: 100.
         updated_since (datetime.datetime | Unset):  Example: 2025-01-02T09:15:00Z.
@@ -165,14 +145,13 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[BalancingEnergyBidsResponse | Problem]
+        Response[ImbalancePriceForecastsResponse | Problem]
     """
 
     kwargs = _get_kwargs(
         area=area,
         period_start_at=period_start_at,
         period_end_at=period_end_at,
-        reserve_type=reserve_type,
         cursor=cursor,
         limit=limit,
         updated_since=updated_since,
@@ -191,38 +170,23 @@ def sync(
     area: Area,
     period_start_at: datetime.datetime,
     period_end_at: datetime.datetime,
-    reserve_type: ReserveType,
     cursor: str | Unset = UNSET,
     limit: int | Unset = 100,
     updated_since: datetime.datetime | Unset = UNSET,
-) -> BalancingEnergyBidsResponse | Problem | None:
-    """Get balancing energy bids
+) -> ImbalancePriceForecastsResponse | Problem | None:
+    """Get imbalance price forecasts for an area
 
-     Returns balancing energy bids for the specified area within the given time period. Prices are in
-    the specified currency per MWh.
+     **Experimental** - This endpoint is under active development and may change without notice.
 
-    Bids are grouped by their shared dimensions (area, reserve type, direction, currency,
-    standard-product flag), and inside each group by delivery period: each entry of `periods` states
-    the period once and carries that period's bids. Period entries ascend by period start within
-    their group.
-
-    Supports cursor-based pagination for large result sets; `limit` counts individual bids, not
-    groups or period entries. Groups and period entries are assembled per page: when `hasMore` is
-    true the last period entry may continue on the next page, so merge entries on their group's
-    dimensions plus the period when accumulating pages. Bids within a period entry are returned in no
-    guaranteed order — sort by price client-side if you need the merit order. When polling with
-    `updated-since`, change is tracked per stored bid set rather than per bid: a changed set is
-    re-delivered with its unchanged bids included, so the period entries of a poll are not
-    necessarily contiguous. A period entry may span more than one tracked set, and a set that
-    changes again mid-drain is deferred to the next poll, so a filtered response is not guaranteed
-    to carry a period's complete bid set — re-fetch without `updated-since` to reconcile
-    withdrawals.
+    Returns imbalance price forecasts for the specified area within the given time period. Each
+    forecast is a predictive distribution: level/price pairs in `quantiles`, ascending by level.
+    An area without forecast coverage returns an empty result rather than an error. Supports
+    cursor-based pagination for large result sets.
 
     Args:
         area (Area): Area code
         period_start_at (datetime.datetime):  Example: 2025-01-01T00:00:00Z.
         period_end_at (datetime.datetime):  Example: 2025-01-02T00:00:00Z.
-        reserve_type (ReserveType): Reserve type
         cursor (str | Unset):  Example: v1:AAAAAYwBAgMEBQYHCAkKCw==.
         limit (int | Unset):  Default: 100. Example: 100.
         updated_since (datetime.datetime | Unset):  Example: 2025-01-02T09:15:00Z.
@@ -232,7 +196,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        BalancingEnergyBidsResponse | Problem
+        ImbalancePriceForecastsResponse | Problem
     """
 
     return sync_detailed(
@@ -240,7 +204,6 @@ def sync(
         area=area,
         period_start_at=period_start_at,
         period_end_at=period_end_at,
-        reserve_type=reserve_type,
         cursor=cursor,
         limit=limit,
         updated_since=updated_since,
@@ -253,38 +216,23 @@ async def asyncio_detailed(
     area: Area,
     period_start_at: datetime.datetime,
     period_end_at: datetime.datetime,
-    reserve_type: ReserveType,
     cursor: str | Unset = UNSET,
     limit: int | Unset = 100,
     updated_since: datetime.datetime | Unset = UNSET,
-) -> Response[BalancingEnergyBidsResponse | Problem]:
-    """Get balancing energy bids
+) -> Response[ImbalancePriceForecastsResponse | Problem]:
+    """Get imbalance price forecasts for an area
 
-     Returns balancing energy bids for the specified area within the given time period. Prices are in
-    the specified currency per MWh.
+     **Experimental** - This endpoint is under active development and may change without notice.
 
-    Bids are grouped by their shared dimensions (area, reserve type, direction, currency,
-    standard-product flag), and inside each group by delivery period: each entry of `periods` states
-    the period once and carries that period's bids. Period entries ascend by period start within
-    their group.
-
-    Supports cursor-based pagination for large result sets; `limit` counts individual bids, not
-    groups or period entries. Groups and period entries are assembled per page: when `hasMore` is
-    true the last period entry may continue on the next page, so merge entries on their group's
-    dimensions plus the period when accumulating pages. Bids within a period entry are returned in no
-    guaranteed order — sort by price client-side if you need the merit order. When polling with
-    `updated-since`, change is tracked per stored bid set rather than per bid: a changed set is
-    re-delivered with its unchanged bids included, so the period entries of a poll are not
-    necessarily contiguous. A period entry may span more than one tracked set, and a set that
-    changes again mid-drain is deferred to the next poll, so a filtered response is not guaranteed
-    to carry a period's complete bid set — re-fetch without `updated-since` to reconcile
-    withdrawals.
+    Returns imbalance price forecasts for the specified area within the given time period. Each
+    forecast is a predictive distribution: level/price pairs in `quantiles`, ascending by level.
+    An area without forecast coverage returns an empty result rather than an error. Supports
+    cursor-based pagination for large result sets.
 
     Args:
         area (Area): Area code
         period_start_at (datetime.datetime):  Example: 2025-01-01T00:00:00Z.
         period_end_at (datetime.datetime):  Example: 2025-01-02T00:00:00Z.
-        reserve_type (ReserveType): Reserve type
         cursor (str | Unset):  Example: v1:AAAAAYwBAgMEBQYHCAkKCw==.
         limit (int | Unset):  Default: 100. Example: 100.
         updated_since (datetime.datetime | Unset):  Example: 2025-01-02T09:15:00Z.
@@ -294,14 +242,13 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[BalancingEnergyBidsResponse | Problem]
+        Response[ImbalancePriceForecastsResponse | Problem]
     """
 
     kwargs = _get_kwargs(
         area=area,
         period_start_at=period_start_at,
         period_end_at=period_end_at,
-        reserve_type=reserve_type,
         cursor=cursor,
         limit=limit,
         updated_since=updated_since,
@@ -318,38 +265,23 @@ async def asyncio(
     area: Area,
     period_start_at: datetime.datetime,
     period_end_at: datetime.datetime,
-    reserve_type: ReserveType,
     cursor: str | Unset = UNSET,
     limit: int | Unset = 100,
     updated_since: datetime.datetime | Unset = UNSET,
-) -> BalancingEnergyBidsResponse | Problem | None:
-    """Get balancing energy bids
+) -> ImbalancePriceForecastsResponse | Problem | None:
+    """Get imbalance price forecasts for an area
 
-     Returns balancing energy bids for the specified area within the given time period. Prices are in
-    the specified currency per MWh.
+     **Experimental** - This endpoint is under active development and may change without notice.
 
-    Bids are grouped by their shared dimensions (area, reserve type, direction, currency,
-    standard-product flag), and inside each group by delivery period: each entry of `periods` states
-    the period once and carries that period's bids. Period entries ascend by period start within
-    their group.
-
-    Supports cursor-based pagination for large result sets; `limit` counts individual bids, not
-    groups or period entries. Groups and period entries are assembled per page: when `hasMore` is
-    true the last period entry may continue on the next page, so merge entries on their group's
-    dimensions plus the period when accumulating pages. Bids within a period entry are returned in no
-    guaranteed order — sort by price client-side if you need the merit order. When polling with
-    `updated-since`, change is tracked per stored bid set rather than per bid: a changed set is
-    re-delivered with its unchanged bids included, so the period entries of a poll are not
-    necessarily contiguous. A period entry may span more than one tracked set, and a set that
-    changes again mid-drain is deferred to the next poll, so a filtered response is not guaranteed
-    to carry a period's complete bid set — re-fetch without `updated-since` to reconcile
-    withdrawals.
+    Returns imbalance price forecasts for the specified area within the given time period. Each
+    forecast is a predictive distribution: level/price pairs in `quantiles`, ascending by level.
+    An area without forecast coverage returns an empty result rather than an error. Supports
+    cursor-based pagination for large result sets.
 
     Args:
         area (Area): Area code
         period_start_at (datetime.datetime):  Example: 2025-01-01T00:00:00Z.
         period_end_at (datetime.datetime):  Example: 2025-01-02T00:00:00Z.
-        reserve_type (ReserveType): Reserve type
         cursor (str | Unset):  Example: v1:AAAAAYwBAgMEBQYHCAkKCw==.
         limit (int | Unset):  Default: 100. Example: 100.
         updated_since (datetime.datetime | Unset):  Example: 2025-01-02T09:15:00Z.
@@ -359,7 +291,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        BalancingEnergyBidsResponse | Problem
+        ImbalancePriceForecastsResponse | Problem
     """
 
     return (
@@ -368,7 +300,6 @@ async def asyncio(
             area=area,
             period_start_at=period_start_at,
             period_end_at=period_end_at,
-            reserve_type=reserve_type,
             cursor=cursor,
             limit=limit,
             updated_since=updated_since,

--- a/clients/python/balancing_services/models/__init__.py
+++ b/clients/python/balancing_services/models/__init__.py
@@ -49,6 +49,10 @@ from .eic_code import EicCode
 from .energy_bid import EnergyBid
 from .imbalance_direction import ImbalanceDirection
 from .imbalance_price import ImbalancePrice
+from .imbalance_price_forecast import ImbalancePriceForecast
+from .imbalance_price_forecast_quantile import ImbalancePriceForecastQuantile
+from .imbalance_price_forecasts import ImbalancePriceForecasts
+from .imbalance_price_forecasts_response import ImbalancePriceForecastsResponse
 from .imbalance_prices import ImbalancePrices
 from .imbalance_prices_response import ImbalancePricesResponse
 from .imbalance_total_volumes import ImbalanceTotalVolumes
@@ -106,6 +110,10 @@ __all__ = (
     "EnergyBid",
     "ImbalanceDirection",
     "ImbalancePrice",
+    "ImbalancePriceForecast",
+    "ImbalancePriceForecastQuantile",
+    "ImbalancePriceForecasts",
+    "ImbalancePriceForecastsResponse",
     "ImbalancePrices",
     "ImbalancePricesResponse",
     "ImbalanceTotalVolumes",

--- a/clients/python/balancing_services/models/imbalance_price_forecast.py
+++ b/clients/python/balancing_services/models/imbalance_price_forecast.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.imbalance_price_forecast_quantile import (
+        ImbalancePriceForecastQuantile,
+    )
+    from ..models.period import Period
+
+
+T = TypeVar("T", bound="ImbalancePriceForecast")
+
+
+@_attrs_define
+class ImbalancePriceForecast:
+    """
+    Attributes:
+        period (Period):
+        quantiles (list[ImbalancePriceForecastQuantile]): The predictive distribution of the price, as one level/price
+            pair per quantile level, ascending by level. Each forecast states the grid it was made on — read the levels off
+            it rather than indexing by a position you hardcoded.
+        made_at (datetime.datetime): When this forecast was made (UTC). Example: 2025-01-01T00:05:00Z.
+        degraded (bool): True when the forecast was computed from incomplete or stale inputs. It is still served, but is
+            less trustworthy — use with care.
+    """
+
+    period: Period
+    quantiles: list[ImbalancePriceForecastQuantile]
+    made_at: datetime.datetime
+    degraded: bool
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        period = self.period.to_dict()
+
+        quantiles = []
+        for quantiles_item_data in self.quantiles:
+            quantiles_item = quantiles_item_data.to_dict()
+            quantiles.append(quantiles_item)
+
+        made_at = self.made_at.isoformat()
+
+        degraded = self.degraded
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "period": period,
+                "quantiles": quantiles,
+                "madeAt": made_at,
+                "degraded": degraded,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.imbalance_price_forecast_quantile import (
+            ImbalancePriceForecastQuantile,
+        )
+        from ..models.period import Period
+
+        d = dict(src_dict)
+        period = Period.from_dict(d.pop("period"))
+
+        quantiles = []
+        _quantiles = d.pop("quantiles")
+        for quantiles_item_data in _quantiles:
+            quantiles_item = ImbalancePriceForecastQuantile.from_dict(
+                quantiles_item_data
+            )
+
+            quantiles.append(quantiles_item)
+
+        made_at = datetime.datetime.fromisoformat(d.pop("madeAt").replace("Z", "+00:00"))
+
+        degraded = d.pop("degraded")
+
+        imbalance_price_forecast = cls(
+            period=period,
+            quantiles=quantiles,
+            made_at=made_at,
+            degraded=degraded,
+        )
+
+        imbalance_price_forecast.additional_properties = d
+        return imbalance_price_forecast
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/balancing_services/models/imbalance_price_forecast_quantile.py
+++ b/clients/python/balancing_services/models/imbalance_price_forecast_quantile.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ImbalancePriceForecastQuantile")
+
+
+@_attrs_define
+class ImbalancePriceForecastQuantile:
+    """
+    Attributes:
+        level (float): The quantile level, as a decimal strictly between 0 and 1 — 0.5 being the median, and the pair
+            0.1/0.9 bounding the central 80% interval. Example: 0.5.
+        price_per_mwh (float): Forecast price per MWh at this level, in the group's currency Example: 45.5.
+    """
+
+    level: float
+    price_per_mwh: float
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        level = self.level
+
+        price_per_mwh = self.price_per_mwh
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "level": level,
+                "pricePerMwh": price_per_mwh,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        level = d.pop("level")
+
+        price_per_mwh = d.pop("pricePerMwh")
+
+        imbalance_price_forecast_quantile = cls(
+            level=level,
+            price_per_mwh=price_per_mwh,
+        )
+
+        imbalance_price_forecast_quantile.additional_properties = d
+        return imbalance_price_forecast_quantile
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/balancing_services/models/imbalance_price_forecasts.py
+++ b/clients/python/balancing_services/models/imbalance_price_forecasts.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.area import Area, check_area
+from ..models.currency import Currency, check_currency
+from ..models.eic_code import EicCode, check_eic_code
+from ..models.imbalance_direction import ImbalanceDirection, check_imbalance_direction
+
+if TYPE_CHECKING:
+    from ..models.imbalance_price_forecast import ImbalancePriceForecast
+
+
+T = TypeVar("T", bound="ImbalancePriceForecasts")
+
+
+@_attrs_define
+class ImbalancePriceForecasts:
+    """
+    Attributes:
+        area (Area): Area code
+        eic_code (EicCode): Energy Identification Code (EIC)
+        currency (Currency): Currency code
+        direction (ImbalanceDirection): Imbalance direction
+        forecasts (list[ImbalancePriceForecast]):
+    """
+
+    area: Area
+    eic_code: EicCode
+    currency: Currency
+    direction: ImbalanceDirection
+    forecasts: list[ImbalancePriceForecast]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        area: str = self.area
+
+        eic_code: str = self.eic_code
+
+        currency: str = self.currency
+
+        direction: str = self.direction
+
+        forecasts = []
+        for forecasts_item_data in self.forecasts:
+            forecasts_item = forecasts_item_data.to_dict()
+            forecasts.append(forecasts_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "area": area,
+                "eicCode": eic_code,
+                "currency": currency,
+                "direction": direction,
+                "forecasts": forecasts,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.imbalance_price_forecast import ImbalancePriceForecast
+
+        d = dict(src_dict)
+        area = check_area(d.pop("area"))
+
+        eic_code = check_eic_code(d.pop("eicCode"))
+
+        currency = check_currency(d.pop("currency"))
+
+        direction = check_imbalance_direction(d.pop("direction"))
+
+        forecasts = []
+        _forecasts = d.pop("forecasts")
+        for forecasts_item_data in _forecasts:
+            forecasts_item = ImbalancePriceForecast.from_dict(forecasts_item_data)
+
+            forecasts.append(forecasts_item)
+
+        imbalance_price_forecasts = cls(
+            area=area,
+            eic_code=eic_code,
+            currency=currency,
+            direction=direction,
+            forecasts=forecasts,
+        )
+
+        imbalance_price_forecasts.additional_properties = d
+        return imbalance_price_forecasts
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/balancing_services/models/imbalance_price_forecasts_response.py
+++ b/clients/python/balancing_services/models/imbalance_price_forecasts_response.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.imbalance_price_forecasts import ImbalancePriceForecasts
+    from ..models.period import Period
+
+
+T = TypeVar("T", bound="ImbalancePriceForecastsResponse")
+
+
+@_attrs_define
+class ImbalancePriceForecastsResponse:
+    """
+    Attributes:
+        queried_period (Period):
+        data (list[ImbalancePriceForecasts]):
+        has_more (bool): Indicates whether there are more results available
+        next_updated_since (datetime.datetime): The watermark to pass as `updated-since` on the next poll. Every page of
+            one drain reports the same value. It deliberately lags real time to cover writes that were still committing, so
+            consecutive polls overlap slightly and a record may be delivered more than once — upsert on consume. Example:
+            2025-01-02T09:15:00Z.
+        next_cursor (None | str | Unset): Cursor to fetch the next page of results. Null if no more results. Example:
+            v1:AAAAAYwBAgMEBQYHCAkKCw==.
+    """
+
+    queried_period: Period
+    data: list[ImbalancePriceForecasts]
+    has_more: bool
+    next_updated_since: datetime.datetime
+    next_cursor: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        queried_period = self.queried_period.to_dict()
+
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_updated_since = self.next_updated_since.isoformat()
+
+        next_cursor: None | str | Unset
+        if isinstance(self.next_cursor, Unset):
+            next_cursor = UNSET
+        else:
+            next_cursor = self.next_cursor
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "queriedPeriod": queried_period,
+                "data": data,
+                "hasMore": has_more,
+                "nextUpdatedSince": next_updated_since,
+            }
+        )
+        if next_cursor is not UNSET:
+            field_dict["nextCursor"] = next_cursor
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.imbalance_price_forecasts import ImbalancePriceForecasts
+        from ..models.period import Period
+
+        d = dict(src_dict)
+        queried_period = Period.from_dict(d.pop("queriedPeriod"))
+
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = ImbalancePriceForecasts.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("hasMore")
+
+        next_updated_since = datetime.datetime.fromisoformat(d.pop("nextUpdatedSince").replace("Z", "+00:00"))
+
+        def _parse_next_cursor(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_cursor = _parse_next_cursor(d.pop("nextCursor", UNSET))
+
+        imbalance_price_forecasts_response = cls(
+            queried_period=queried_period,
+            data=data,
+            has_more=has_more,
+            next_updated_since=next_updated_since,
+            next_cursor=next_cursor,
+        )
+
+        imbalance_price_forecasts_response.additional_properties = d
+        return imbalance_price_forecasts_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/tests/test_basic.py
+++ b/clients/python/tests/test_basic.py
@@ -22,8 +22,15 @@ from balancing_services.api.default import (
     get_cross_border_marginal_prices,
     get_current_imbalance_total_volumes,
     get_day_ahead_energy_prices,
+    get_imbalance_price_forecasts,
     get_imbalance_prices,
     get_imbalance_total_volumes,
+)
+from balancing_services.models import (
+    ImbalancePriceForecast,
+    ImbalancePriceForecastQuantile,
+    ImbalancePriceForecasts,
+    ImbalancePriceForecastsResponse,
 )
 from balancing_services.models.activation_type import ACTIVATION_TYPE_VALUES
 from balancing_services.models.area import AREA_VALUES
@@ -69,10 +76,32 @@ class TestAPIEndpointsExist:
         """Test that imbalance endpoints are available."""
         assert hasattr(get_imbalance_prices, "sync_detailed")
         assert hasattr(get_imbalance_prices, "asyncio_detailed")
+        assert hasattr(get_imbalance_price_forecasts, "sync_detailed")
+        assert hasattr(get_imbalance_price_forecasts, "asyncio_detailed")
         assert hasattr(get_imbalance_total_volumes, "sync_detailed")
         assert hasattr(get_imbalance_total_volumes, "asyncio_detailed")
         assert hasattr(get_current_imbalance_total_volumes, "sync_detailed")
         assert hasattr(get_current_imbalance_total_volumes, "asyncio_detailed")
+
+    def test_imbalance_price_forecast_models_exist(self):
+        """Test that the imbalance price forecast models are exported and shaped as expected."""
+        forecast = ImbalancePriceForecast.from_dict(
+            {
+                "period": {
+                    "startAt": "2025-01-01T00:00:00Z",
+                    "endAt": "2025-01-01T00:15:00Z",
+                },
+                "quantiles": [{"level": 0.5, "pricePerMwh": 45.5}],
+                "madeAt": "2025-01-01T00:05:00Z",
+                "degraded": False,
+            }
+        )
+        assert forecast.degraded is False
+        assert isinstance(forecast.quantiles[0], ImbalancePriceForecastQuantile)
+        assert forecast.quantiles[0].level == 0.5
+        assert forecast.quantiles[0].price_per_mwh == 45.5
+        assert hasattr(ImbalancePriceForecasts, "from_dict")
+        assert hasattr(ImbalancePriceForecastsResponse, "from_dict")
 
     def test_balancing_energy_endpoints_exist(self):
         """Test that balancing energy endpoints are available."""

--- a/clients/python/tests/test_integration.py
+++ b/clients/python/tests/test_integration.py
@@ -21,6 +21,7 @@ from balancing_services.api.default import (
     get_cross_zonal_capacity_allocation,
     get_current_imbalance_total_volumes,
     get_day_ahead_energy_prices,
+    get_imbalance_price_forecasts,
     get_imbalance_prices,
 )
 
@@ -1594,3 +1595,202 @@ async def test_async_get_day_ahead_energy_prices(authenticated_client, mock_day_
     assert len(response.parsed.data) == 1
     assert response.parsed.data[0].area == "FI"
     assert response.parsed.data[0].prices[0].price_per_mwh == 45.67
+
+
+@pytest.fixture
+def mock_imbalance_price_forecasts_response():
+    """Mock response data for imbalance price forecasts (nowcasts)."""
+    return {
+        "queriedPeriod": {
+            "startAt": "2025-01-01T00:00:00Z",
+            "endAt": "2025-01-01T01:00:00Z"
+        },
+        "hasMore": False,
+        "nextUpdatedSince": "2025-01-01T00:20:00Z",
+        "data": [
+            {
+                "area": "EE",
+                "eicCode": "10Y1001A1001A39I",
+                "currency": "EUR",
+                "direction": "symmetric",
+                "forecasts": [
+                    {
+                        "period": {
+                            "startAt": "2025-01-01T00:00:00Z",
+                            "endAt": "2025-01-01T00:15:00Z"
+                        },
+                        "quantiles": [
+                            {"level": 0.1, "pricePerMwh": 12.5},
+                            {"level": 0.5, "pricePerMwh": 45.5},
+                            {"level": 0.9, "pricePerMwh": 98.0}
+                        ],
+                        "madeAt": "2025-01-01T00:05:00Z",
+                        "degraded": False
+                    },
+                    {
+                        "period": {
+                            "startAt": "2025-01-01T00:15:00Z",
+                            "endAt": "2025-01-01T00:30:00Z"
+                        },
+                        "quantiles": [
+                            {"level": 0.1, "pricePerMwh": 10.0},
+                            {"level": 0.5, "pricePerMwh": 40.0},
+                            {"level": 0.9, "pricePerMwh": 91.0}
+                        ],
+                        "madeAt": "2025-01-01T00:05:00Z",
+                        "degraded": True
+                    }
+                ]
+            }
+        ]
+    }
+
+
+@respx.mock
+def test_get_imbalance_price_forecasts_success(authenticated_client, mock_imbalance_price_forecasts_response):
+    """Test successful imbalance price forecasts request."""
+    respx.get(
+        "https://api.balancing.services/v2/imbalance/prices/forecast"
+    ).mock(return_value=Response(200, json=mock_imbalance_price_forecasts_response))
+
+    response = get_imbalance_price_forecasts.sync_detailed(
+        client=authenticated_client,
+        area="EE",
+        period_start_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        period_end_at=datetime(2025, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+    )
+
+    assert response.status_code == 200
+    assert response.parsed is not None
+    assert response.parsed.has_more is False
+    assert response.parsed.queried_period.start_at == datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    assert len(response.parsed.data) == 1
+    assert response.parsed.data[0].area == "EE"
+    assert response.parsed.data[0].eic_code == "10Y1001A1001A39I"
+    assert response.parsed.data[0].currency == "EUR"
+    assert response.parsed.data[0].direction == "symmetric"
+
+    forecast = response.parsed.data[0].forecasts[0]
+    assert forecast.period.start_at == datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    assert forecast.degraded is False
+    assert forecast.made_at == datetime(2025, 1, 1, 0, 5, 0, tzinfo=timezone.utc)
+    # Quantiles are level/price pairs, ascending by level - read the levels off the
+    # forecast rather than indexing by a hardcoded position.
+    levels = [quantile.level for quantile in forecast.quantiles]
+    assert levels == sorted(levels)
+    assert all(0 < level < 1 for level in levels)
+    median = next(quantile for quantile in forecast.quantiles if quantile.level == 0.5)
+    assert median.price_per_mwh == 45.5
+    assert response.parsed.data[0].forecasts[1].degraded is True
+
+
+@respx.mock
+def test_get_imbalance_price_forecasts_unserved_area_is_empty(authenticated_client):
+    """Test that an area without forecast coverage returns an empty result, not an error."""
+    empty_response = {
+        "queriedPeriod": {
+            "startAt": "2025-01-01T00:00:00Z",
+            "endAt": "2025-01-01T01:00:00Z"
+        },
+        "hasMore": False,
+        "nextUpdatedSince": "2025-01-01T00:20:00Z",
+        "data": []
+    }
+
+    respx.get(
+        "https://api.balancing.services/v2/imbalance/prices/forecast"
+    ).mock(return_value=Response(200, json=empty_response))
+
+    response = get_imbalance_price_forecasts.sync_detailed(
+        client=authenticated_client,
+        area="FI",
+        period_start_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        period_end_at=datetime(2025, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+    )
+
+    assert response.status_code == 200
+    assert response.parsed is not None
+    assert response.parsed.data == []
+    assert response.parsed.has_more is False
+
+
+@respx.mock
+def test_get_imbalance_price_forecasts_pagination(authenticated_client, mock_imbalance_price_forecasts_response):
+    """Test imbalance price forecasts pagination - cursor/limit/updated-since sent, nextCursor parsed."""
+    paginated_response = {
+        **mock_imbalance_price_forecasts_response,
+        "hasMore": True,
+        "nextCursor": "v1:AAAAAYwBAgMEBQYHCAkKCw==",
+    }
+
+    route = respx.get(
+        "https://api.balancing.services/v2/imbalance/prices/forecast"
+    ).mock(return_value=Response(200, json=paginated_response))
+
+    response = get_imbalance_price_forecasts.sync_detailed(
+        client=authenticated_client,
+        area="EE",
+        period_start_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        period_end_at=datetime(2025, 1, 1, 1, 0, 0, tzinfo=timezone.utc),
+        cursor="v1:AAAAAYwBAgMEBQYHCAkKCw==",
+        limit=100,
+        updated_since=datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert response.status_code == 200
+    assert response.parsed is not None
+    assert response.parsed.has_more is True
+    assert response.parsed.next_cursor == "v1:AAAAAYwBAgMEBQYHCAkKCw=="
+    assert response.parsed.next_updated_since == datetime(2025, 1, 1, 0, 20, 0, tzinfo=timezone.utc)
+    sent_url = route.calls.last.request.url
+    assert sent_url.params["cursor"] == "v1:AAAAAYwBAgMEBQYHCAkKCw=="
+    assert sent_url.params["limit"] == "100"
+    assert sent_url.params["updated-since"] == "2025-01-01T00:00:00+00:00"
+
+
+@respx.mock
+def test_get_imbalance_price_forecasts_unauthorized(authenticated_client):
+    """Test unauthorized response (401) for imbalance price forecasts."""
+    error_response = {
+        "type": "unauthorized",
+        "title": "Unauthorized",
+        "status": 401,
+        "detail": "Invalid or missing authentication token"
+    }
+
+    respx.get(
+        "https://api.balancing.services/v2/imbalance/prices/forecast"
+    ).mock(return_value=Response(401, json=error_response))
+
+    response = get_imbalance_price_forecasts.sync_detailed(
+        client=authenticated_client,
+        area="EE",
+        period_start_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        period_end_at=datetime(2025, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+    )
+
+    assert response.status_code == 401
+    assert response.parsed is not None
+    assert response.parsed.status == 401
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_async_get_imbalance_price_forecasts(authenticated_client, mock_imbalance_price_forecasts_response):
+    """Test async request for imbalance price forecasts."""
+    respx.get(
+        "https://api.balancing.services/v2/imbalance/prices/forecast"
+    ).mock(return_value=Response(200, json=mock_imbalance_price_forecasts_response))
+
+    response = await get_imbalance_price_forecasts.asyncio_detailed(
+        client=authenticated_client,
+        area="EE",
+        period_start_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        period_end_at=datetime(2025, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+    )
+
+    assert response.status_code == 200
+    assert response.parsed is not None
+    assert len(response.parsed.data) == 1
+    assert len(response.parsed.data[0].forecasts) == 2
+    assert response.parsed.data[0].forecasts[0].quantiles[1].price_per_mwh == 45.5

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,6 +57,55 @@ paths:
         '501':
           $ref: '#/components/responses/NotImplemented'
 
+  /imbalance/prices/forecast:
+    get:
+      summary: Get imbalance price forecasts for an area
+      description: |
+        **Experimental** - This endpoint is under active development and may change without notice.
+
+        Returns imbalance price forecasts for the specified area within the given time period. Each
+        forecast is a predictive distribution: level/price pairs in `quantiles`, ascending by level.
+        An area without forecast coverage returns an empty result rather than an error. Supports
+        cursor-based pagination for large result sets.
+      operationId: getImbalancePriceForecasts
+      parameters:
+        - $ref: '#/components/parameters/area'
+        - $ref: '#/components/parameters/period-start-at'
+        - $ref: '#/components/parameters/period-end-at'
+        - $ref: '#/components/parameters/cursor'
+        - name: limit
+          in: query
+          description: Maximum number of results to return (default 100, max 1000)
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+            example: 100
+        - $ref: '#/components/parameters/updated-since'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImbalancePriceForecastsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+
   /imbalance/total-volumes:
     get:
       summary: Get total imbalance volumes for an area
@@ -1237,6 +1286,105 @@ components:
         pricePerMwh:
           type: number
           description: Price per MWh in the specified currency
+          example: 45.50
+
+    ImbalancePriceForecastsResponse:
+      type: object
+      required:
+        - queriedPeriod
+        - data
+        - hasMore
+        - nextUpdatedSince
+      properties:
+        queriedPeriod:
+          $ref: '#/components/schemas/Period'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ImbalancePriceForecasts'
+        nextCursor:
+          type: string
+          description: Cursor to fetch the next page of results. Null if no more results.
+          example: 'v1:AAAAAYwBAgMEBQYHCAkKCw=='
+          nullable: true
+        hasMore:
+          type: boolean
+          description: Indicates whether there are more results available
+          example: false
+        nextUpdatedSince:
+          $ref: '#/components/schemas/NextUpdatedSince'
+
+    ImbalancePriceForecasts:
+      type: object
+      required:
+        - area
+        - eicCode
+        - currency
+        - direction
+        - forecasts
+      properties:
+        area:
+          $ref: '#/components/schemas/Area'
+        eicCode:
+          $ref: '#/components/schemas/EicCode'
+        currency:
+          $ref: '#/components/schemas/Currency'
+        direction:
+          $ref: '#/components/schemas/ImbalanceDirection'
+        forecasts:
+          type: array
+          items:
+            $ref: '#/components/schemas/ImbalancePriceForecast'
+
+    ImbalancePriceForecast:
+      type: object
+      required:
+        - period
+        - quantiles
+        - madeAt
+        - degraded
+      properties:
+        period:
+          $ref: '#/components/schemas/Period'
+        quantiles:
+          type: array
+          description: >-
+            The predictive distribution of the price, as one level/price pair per quantile level,
+            ascending by level. Each forecast states the grid it was made on — read the levels off
+            it rather than indexing by a position you hardcoded.
+          items:
+            $ref: '#/components/schemas/ImbalancePriceForecastQuantile'
+        madeAt:
+          type: string
+          format: date-time
+          description: When this forecast was made (UTC).
+          example: '2025-01-01T00:05:00Z'
+        degraded:
+          type: boolean
+          description: >-
+            True when the forecast was computed from incomplete or stale inputs. It is still
+            served, but is less trustworthy — use with care.
+          example: false
+
+    ImbalancePriceForecastQuantile:
+      type: object
+      required:
+        - level
+        - pricePerMwh
+      properties:
+        level:
+          type: number
+          description: >-
+            The quantile level, as a decimal strictly between 0 and 1 — 0.5 being the median, and
+            the pair 0.1/0.9 bounding the central 80% interval.
+          minimum: 0
+          exclusiveMinimum: true
+          maximum: 1
+          exclusiveMaximum: true
+          example: 0.5
+        pricePerMwh:
+          type: number
+          description: Forecast price per MWh at this level, in the group's currency
           example: 45.50
 
     ImbalanceTotalVolumesResponse:

--- a/skills/balancing-services-api/SKILL.md
+++ b/skills/balancing-services-api/SKILL.md
@@ -50,6 +50,7 @@ All take `period-start-at` and `period-end-at`; the last column lists what else 
 | Endpoint | Returns | Also required |
 |---|---|---|
 | `GET /imbalance/prices` | Imbalance prices per MWh, grouped by direction (`positive`/`symmetric`/`negative`) | `area` |
+| `GET /imbalance/prices/forecast` | Experimental. Imbalance price forecasts as predictive distributions: `quantiles` gives one level/price pair per quantile level, ascending by level; `degraded` flags a less trustworthy forecast | `area` |
 | `GET /imbalance/total-volumes` | Settled total imbalance volume as average power, direction `surplus`/`deficit`/`balanced` per period | `area` |
 | `GET /imbalance/total-volumes/current` | Experimental. Provisional open area control error at 1-minute resolution, roughly 25 min behind real time, ~90 days retained | `area` |
 | `GET /balancing/energy/activated-volumes` | Activated balancing energy as average power in MW, by direction and activation type | `area`, `reserve-type` |
@@ -124,6 +125,9 @@ references/pagination-and-polling.md).
   `localDemandInMw`. There are no unit-less aliases on v2.
 - **Capacity demand can double-count.** Sum only `additive` demand across procurements of one
   period; `substitutive` restates demand already covered by another procurement.
+- **Forecast quantiles are self-describing.** Each forecast on `/imbalance/prices/forecast` states
+  the grid it was made on — read `level` off every quantile rather than indexing by a position you
+  hardcoded. Levels are decimals strictly between 0 and 1 (0.5 the median).
 - **Currency varies by area** (`EUR`, `BGN`, `CHF`, `HUF`, `PLN`, `RON`, `UAH`) and is stated per
   group — never assume euros.
 


### PR DESCRIPTION
Document /imbalance/prices/forecast, serving forecasts of the imbalance
price. The Python client is regenerated, and the changelog and the
skill's endpoint catalogue gain matching entries.
