### PR TITLE
Release 2.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "balancing-services-rest-api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Skill for integrating with the Balancing Services REST API — European electricity balancing market data.",
   "author": {
     "name": "Balancing Services",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-11
+
 ### Added
 - Experimental imbalance price revision history endpoint (`/imbalance/prices/history`), serving how the prices on `/imbalance/prices` reached their current values — see the endpoint description for the semantics
 
@@ -221,7 +223,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UTC timestamp-based period filtering
 - OpenAPI 3.0.3 specification
 
-[Unreleased]: https://github.com/balancing-services/rest-api/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/balancing-services/rest-api/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/balancing-services/rest-api/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/balancing-services/rest-api/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/balancing-services/rest-api/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/balancing-services/rest-api/compare/v2.0.0...v2.0.1

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Balancing Services REST API
-  version: 2.1.0
+  version: 2.2.0
   description: REST API for balancing services data
   contact:
     name: Balancing Services Team


### PR DESCRIPTION
Bump the spec and plugin versions and stamp the 2.2.0 CHANGELOG section
released. Since 2.1.0 the spec gains the experimental imbalance price
history endpoint, serving the revision history of the imbalance prices
on /imbalance/prices.
